### PR TITLE
feat: decision context auto-registration and bug fixes (v5.0.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [5.0.4] - 2026-02-04
+
+### Added
+
+**📌 Decision Context Auto-Registration from Plan Mode**
+
+- Plan-to-ADR pipeline now automatically extracts and registers decision context (rationale, alternatives, tradeoffs) from plan files
+- New `decision_context` queue item type in `.sqlew/queue/pending.json`
+- `plan-pattern-extractor.ts`: Extracts `Rationale`, `Alternatives`, `Tradeoffs` fields from `📌 Decision` blocks
+- `plan-processor.ts`: Enqueues `decision_context` items after corresponding `decision` items (ordering guaranteed)
+- `hook-queue.ts`: New `enqueueDecisionContextCreate()` with duplicate prevention
+- `queue-watcher.ts`: New `processDecisionContextItem()` converts comma-separated alternatives to JSON array, routes through ToolBackend abstraction
+
+### SaaS Compatibility
+
+- `add_decision_context` action fully supported via SaaS backend (`/api/v1/decision/add_decision_context`)
+- `suggest/by_context` for constraints: improved text matching for long constraint texts (server-side Levenshtein fix)
+
+---
+
 ## [5.0.3] - 2026-02-04
 
 ### Fixed

--- a/assets/claude-md-snippets/plan-mode-integration.md
+++ b/assets/claude-md-snippets/plan-mode-integration.md
@@ -51,6 +51,9 @@ suggest { action: "by_context", target: "constraint", text: "<topic>" }
 - **Value**: Description of the decision
 - **Layer**: presentation | business | data | infrastructure | cross-cutting
 - **Tags**: tag1, tag2 (optional)
+- **Rationale**: Why this decision was made (optional)
+- **Alternatives**: Option A, Option B (optional, comma-separated)
+- **Tradeoffs**: Pros and cons description (optional)
 ```
 
 **Constraint format (REQUIRED when user specifies restrictions):**

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "sqlew",
   "display_name": "sqlew - Context Manager for AI Agents",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Token-efficient context management for AI coding agents. Record architectural decisions, constraints, and maintain project knowledge across sessions. Supports SQLite local storage and sqlew.io cloud backend.",
   "author": {
     "name": "sqlew.io",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sqlew",
   "description": "Automated ADR (Architecture Decision Records) for Claude Code - MCP server with SQL-backed decision repository",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "main": "dist/index.js",
   "type": "module",
   "bin": {

--- a/src/cli/hooks/plan-pattern-extractor.ts
+++ b/src/cli/hooks/plan-pattern-extractor.ts
@@ -40,6 +40,12 @@ export interface ExtractedDecision {
   layer?: string;
   /** Tags for the decision (comma-separated) */
   tags?: string;
+  /** Why this decision was made (for decision context) */
+  rationale?: string;
+  /** Alternatives considered (comma-separated) */
+  alternatives?: string;
+  /** Tradeoffs description */
+  tradeoffs?: string;
 }
 
 /**
@@ -122,6 +128,9 @@ export function extractPatternsFromPlan(content: string): ExtractionResult {
       value,
       layer: normalizeLayer(extractField(body, 'Layer')),
       tags: extractField(body, 'Tags'),
+      rationale: extractField(body, 'Rationale') || undefined,
+      alternatives: extractField(body, 'Alternatives') || undefined,
+      tradeoffs: extractField(body, 'Tradeoffs') || undefined,
     });
   }
 
@@ -271,7 +280,15 @@ export function buildConfirmationMessage(extracted: ExtractionResult, planFile: 
   if (extracted.decisions.length > 0) {
     lines.push(`### ✅ Decisions (${extracted.decisions.length}) → auto-registered as draft`);
     for (const d of extracted.decisions) {
-      lines.push(`- **${d.key}**: ${d.value}`);
+      const contextParts: string[] = [];
+      if (d.rationale) contextParts.push('rationale');
+      if (d.alternatives) {
+        const count = d.alternatives.split(',').filter(s => s.trim()).length;
+        contextParts.push(`${count} alternative${count > 1 ? 's' : ''}`);
+      }
+      if (d.tradeoffs) contextParts.push('tradeoffs');
+      const contextSuffix = contextParts.length > 0 ? ` + context (${contextParts.join(', ')})` : '';
+      lines.push(`- **${d.key}**: ${d.value}${contextSuffix}`);
       if (d.layer) lines.push(`  - Layer: ${d.layer}`);
     }
     lines.push('');

--- a/src/cli/hooks/plan-processor.ts
+++ b/src/cli/hooks/plan-processor.ts
@@ -12,7 +12,7 @@
 
 import { readFileSync } from 'fs';
 import { loadCurrentPlan, saveCurrentPlan, type CurrentPlanInfo } from '../../config/global-config.js';
-import { enqueueDecisionCreate, enqueueConstraintCreate } from '../../utils/hook-queue.js';
+import { enqueueDecisionCreate, enqueueConstraintCreate, enqueueDecisionContextCreate } from '../../utils/hook-queue.js';
 import {
   extractPatternsFromPlan,
   hasPatterns,
@@ -113,6 +113,16 @@ export function processPlanPatterns(projectPath: string): ProcessPlanResult {
       layer: decision.layer || 'cross-cutting',
       tags: allTags,
     });
+
+    // Enqueue decision context if rationale exists (after DecisionCreate for ordering)
+    if (decision.rationale) {
+      enqueueDecisionContextCreate(projectPath, {
+        key: decision.key,
+        rationale: decision.rationale,
+        alternatives: decision.alternatives,
+        tradeoffs: decision.tradeoffs,
+      });
+    }
   }
 
   for (const constraint of extracted.constraints) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,10 +70,12 @@ async function startMcpServer(): Promise<void> {
   }
 
   // Create MCP server
+  // TODO: Migrate from deprecated `Server` to `McpServer` (high-level API)
+  // See: @modelcontextprotocol/sdk/server/mcp.js
   const server = new Server(
     {
       name: 'sqlew',
-      version: '5.0.3',
+      version: '5.0.4',
     },
     {
       capabilities: {

--- a/src/utils/hook-queue.ts
+++ b/src/utils/hook-queue.ts
@@ -129,8 +129,25 @@ export interface ConstraintQueueItem {
   };
 }
 
+/** Queue item for decision context operations */
+export interface DecisionContextQueueItem {
+  type: 'decision_context';
+  action: 'create';
+  timestamp: string;
+  data: {
+    /** Decision key to attach context to */
+    key: string;
+    /** Why this decision was made (required) */
+    rationale: string;
+    /** Alternatives considered (comma-separated) */
+    alternatives?: string;
+    /** Tradeoffs description */
+    tradeoffs?: string;
+  };
+}
+
 /** Union type for all queue items */
-export type QueueItem = DecisionQueueItem | ConstraintQueueItem;
+export type QueueItem = DecisionQueueItem | ConstraintQueueItem | DecisionContextQueueItem;
 
 /** Queue file structure */
 export interface QueueFile {
@@ -601,6 +618,63 @@ export function clearQueue(projectPath: string): void {
 export function hasQueueItems(projectPath: string): boolean {
   const queue = readQueue(projectPath);
   return queue.items.length > 0;
+}
+
+// ============================================================================
+// Decision Context Queue Operations (v5.0.4+)
+// ============================================================================
+
+/**
+ * Enqueue a decision context creation
+ *
+ * Must be enqueued AFTER the corresponding DecisionCreate item
+ * to ensure the decision exists when context is processed.
+ *
+ * @param projectPath - Project root path
+ * @param data - Decision context data
+ */
+export function enqueueDecisionContextCreate(
+  projectPath: string,
+  data: {
+    key: string;
+    rationale: string;
+    alternatives?: string;
+    tradeoffs?: string;
+  }
+): void {
+  writeQueueTrace(projectPath, 'INFO', 'enqueueDecisionContextCreate: START', { key: data.key });
+  const queue = readQueue(projectPath);
+  writeQueueTrace(projectPath, 'INFO', 'enqueueDecisionContextCreate: after readQueue', { existingItems: queue.items.length });
+
+  // Duplicate check: skip if same key + rationale prefix already in queue
+  const rationalePrefix = data.rationale.slice(0, 30);
+  const existingContext = queue.items.find(
+    i => i.type === 'decision_context'
+      && (i as DecisionContextQueueItem).data.key === data.key
+      && (i as DecisionContextQueueItem).data.rationale.slice(0, 30) === rationalePrefix
+  );
+  if (existingContext) {
+    writeQueueTrace(projectPath, 'WARN', 'enqueueDecisionContextCreate: SKIP duplicate', { key: data.key });
+    debugLog('INFO', '[hook-queue] Skipping duplicate decision context in queue', { key: data.key });
+    return;
+  }
+
+  const item: DecisionContextQueueItem = {
+    type: 'decision_context',
+    action: 'create',
+    timestamp: new Date().toISOString(),
+    data,
+  };
+  queue.items.push(item);
+  writeQueueTrace(projectPath, 'INFO', 'enqueueDecisionContextCreate: before writeQueue', { totalItems: queue.items.length });
+  debugLog('INFO', '[hook-queue] enqueueDecisionContextCreate', {
+    projectPath,
+    key: data.key,
+    rationalePreview: data.rationale?.slice(0, 30),
+    queueSizeAfter: queue.items.length,
+  });
+  writeQueue(projectPath, queue, 'enqueueDecisionContextCreate');
+  writeQueueTrace(projectPath, 'INFO', 'enqueueDecisionContextCreate: DONE');
 }
 
 // ============================================================================

--- a/src/watcher/queue-watcher.ts
+++ b/src/watcher/queue-watcher.ts
@@ -15,7 +15,7 @@
 import { join, dirname } from 'path';
 import { existsSync, mkdirSync } from 'fs';
 import { BaseWatcher } from './base-watcher.js';
-import { getQueuePath, hasQueueItems, processQueue, type QueueItem, type DecisionQueueItem, type ConstraintQueueItem } from '../utils/hook-queue.js';
+import { getQueuePath, hasQueueItems, processQueue, type QueueItem, type DecisionQueueItem, type ConstraintQueueItem, type DecisionContextQueueItem } from '../utils/hook-queue.js';
 import { debugLog } from '../utils/debug-logger.js';
 import type { ToolBackend } from '../backend/types.js';
 
@@ -174,6 +174,8 @@ export class QueueWatcher extends BaseWatcher {
       await this.processDecisionItem(item as DecisionQueueItem);
     } else if (item.type === 'constraint') {
       await this.processConstraintItem(item as ConstraintQueueItem);
+    } else if (item.type === 'decision_context') {
+      await this.processDecisionContextItem(item as DecisionContextQueueItem);
     }
   }
 
@@ -256,6 +258,35 @@ export class QueueWatcher extends BaseWatcher {
         });
       }
     }
+  }
+
+  /**
+   * Process a decision context queue item
+   * Calls add_decision_context to attach rationale/alternatives/tradeoffs to a decision
+   * @since v5.0.4
+   */
+  private async processDecisionContextItem(item: DecisionContextQueueItem): Promise<void> {
+    const { data } = item;
+
+    debugLog('INFO', `${this.watcherName}: Processing decision_context create`, {
+      callId: this.currentCallId,
+      key: data.key,
+      rationalePreview: data.rationale?.slice(0, 50),
+    });
+
+    // Convert comma-separated alternatives to JSON array string
+    let alternatives: string | null = null;
+    if (data.alternatives) {
+      const items = data.alternatives.split(',').map(s => s.trim()).filter(Boolean);
+      alternatives = JSON.stringify(items);
+    }
+
+    await this.backend.execute('decision', 'add_decision_context', {
+      key: data.key,
+      rationale: data.rationale,
+      alternatives_considered: alternatives,
+      tradeoffs: data.tradeoffs || null,
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary

- **Decision Context Auto-Registration**: Plan-to-ADR pipeline now extracts `Rationale`, `Alternatives`, `Tradeoffs` from 📌 Decision blocks and auto-registers them as decision context via ToolBackend abstraction
- **Zombie Process Fix (v5.0.3)**: Resolved MCP server processes surviving after Claude Code exit on Windows, added v5 schema detection
- **SaaS Compatibility**: `add_decision_context` and `suggest/by_context` for constraints verified working via SaaS backend

## Changes

### v5.0.4 - Decision Context Auto-Registration
- `plan-pattern-extractor.ts`: Extract Rationale/Alternatives/Tradeoffs fields
- `plan-processor.ts`: Enqueue `decision_context` items after corresponding `decision` items (ordering guaranteed)
- `hook-queue.ts`: New `DecisionContextQueueItem` type and `enqueueDecisionContextCreate()` with duplicate prevention
- `queue-watcher.ts`: New `processDecisionContextItem()` converts comma-separated alternatives to JSON array
- `plan-mode-integration.md`: Updated decision format snippet with context fields
- Version bump to v5.0.4 across package.json, manifest.json, index.ts

### v5.0.3 - Bug Fixes
- Fixed zombie process on parent exit (stdin `end` handler + QueueWatcher shutdown)
- Fixed v5 schema version detection (`m_projects` + `t_decisions` check)
- Added `.mcpbignore` and updated `.gitignore`

## Test plan

- [x] TypeScript build passes
- [x] 573/573 tests pass
- [x] Decision context auto-registration verified (local backend)
- [x] Decision context auto-registration verified (SaaS backend)
- [x] suggest/by_context for constraints verified (SaaS backend)
- [x] Queue ordering: decision → decision_context guaranteed
- [x] Alternatives comma-to-JSON-array conversion verified
- [x] Failed queue empty after processing