### PR TITLE
fix: add GITHUB_TOKEN env to sync-dev workflow

### DIFF
--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -21,3 +21,5 @@ jobs:
           git checkout dev
           git reset --hard origin/main
           git push --force origin dev
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fix GitHub Actions `sync-dev.yml` workflow failing on push.

## Changes

- Add `GITHUB_TOKEN` env variable to the push step for proper authentication

## Test plan

- [x] Merge this PR
- [x] Check if sync-dev workflow succeeds on next main push