### PR TITLE
fix: accept numeric priority in constraint tool (#91)

### DIFF
--- a/scripts/filter-test-output.js
+++ b/scripts/filter-test-output.js
@@ -20,6 +20,9 @@ const includePattern = /(✖|Error|FAIL)/;
 // Pattern matches: passing tests, test start markers (lines to EXCLUDE)
 const excludePattern = /(✔|✅|▶)/;
 
+// Pattern matches: TAP pass lines and subtest headers (never failures)
+const tapNonFailurePattern = /^\s*(ok \d|# Subtest:)/;
+
 // Pattern to detect final summary section (lines starting with ℹ)
 const summaryPattern = /^ℹ /;
 
@@ -49,7 +52,8 @@ rl.on('line', (line) => {
   }
 
   // Check if current line is a failure
-  const isFailure = includePattern.test(line) && !excludePattern.test(line);
+  // Exclude TAP pass lines (ok N) and subtest headers (# Subtest:) that may contain "Error" in test names
+  const isFailure = includePattern.test(line) && !excludePattern.test(line) && !tapNonFailurePattern.test(line);
 
   if (isFailure) {
     hasFailures = true; // Mark that we detected failures

--- a/src/help-data/constraint.toml
+++ b/src/help-data/constraint.toml
@@ -33,10 +33,10 @@ description = "Add a new constraint with priority"
 
   [[actions.params]]
   name = "priority"
-  type = "number"
+  type = "string"
   required = false
-  description = "Priority: 1=low, 2=medium, 3=high, 4=critical"
-  default = "2"
+  description = "Priority: low, medium, high, critical (or 1-4)"
+  default = "medium"
 
   [[actions.params]]
   name = "layer"
@@ -58,7 +58,7 @@ description = "Add a new constraint with priority"
   "action": "add",
   "constraint_text": "All API endpoints must require authentication",
   "category": "security",
-  "priority": 4,
+  "priority": "critical",
   "layer": "presentation"
 }
 '''
@@ -71,7 +71,7 @@ description = "Add a new constraint with priority"
   "action": "add",
   "constraint_text": "Use functional components with hooks instead of class components",
   "category": "code-style",
-  "priority": 2,
+  "priority": "medium",
   "tags": ["react", "frontend"]
 }
 '''
@@ -103,9 +103,9 @@ description = "Retrieve constraints with filtering"
 
   [[actions.params]]
   name = "priority"
-  type = "number"
+  type = "string"
   required = false
-  description = "Filter by minimum priority"
+  description = "Filter by priority: low, medium, high, critical (or 1-4)"
 
   [[actions.params]]
   name = "active_only"
@@ -129,10 +129,10 @@ description = "Retrieve constraints with filtering"
   code = '''
 {
   "action": "get",
-  "priority": 4
+  "priority": "critical"
 }
 '''
-  explanation = "Retrieve all critical (priority 4) constraints"
+  explanation = "Retrieve all critical constraints"
 
 # -----------------------------------------------------------------------------
 

--- a/src/tools/constraints/actions/add.ts
+++ b/src/tools/constraints/actions/add.ts
@@ -54,9 +54,8 @@ export async function addConstraint(
       // Validate category
       validateCategory(normalizedParams.category);
 
-      // Validate priority if provided
-      const priorityStr = normalizedParams.priority || 'medium';
-      validatePriority(priorityStr);
+      // Validate priority if provided (accepts string or number)
+      const priorityStr = validatePriority(normalizedParams.priority || 'medium');
       const priority = STRING_TO_PRIORITY[priorityStr] || DEFAULT_PRIORITY;
 
       // Validate and get layer ID if provided

--- a/src/tools/constraints/actions/get.ts
+++ b/src/tools/constraints/actions/get.ts
@@ -5,7 +5,7 @@
 
 import { DatabaseAdapter } from '../../../adapters/index.js';
 import { getAdapter } from '../../../database.js';
-import { validateCategory } from '../../../utils/validators.js';
+import { validateCategory, validatePriority } from '../../../utils/validators.js';
 import { validateActionParams } from '../../../utils/parameter-validator.js';
 import { parseStringArray } from '../../../utils/param-parser.js';
 import { getProjectContext } from '../../../utils/project-context.js';
@@ -66,13 +66,13 @@ export async function getConstraints(
         query = query.where('l.name', params.layer);
       }
 
-      // Filter by priority
+      // Filter by priority (accepts string or number)
       if (params.priority) {
-        // Convert priority string to integer for DB query
+        const priorityStr = validatePriority(params.priority as string | number);
         const priorityMap: Record<string, number> = {
           low: 1, medium: 2, high: 3, critical: 4
         };
-        const priorityInt = priorityMap[params.priority];
+        const priorityInt = priorityMap[priorityStr];
         if (priorityInt !== undefined) {
           query = query.where('c.priority', priorityInt);
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -419,7 +419,7 @@ export interface ExportBlocks {
 export interface AddConstraintParams {
   category: string;
   constraint_text: string;
-  priority?: 'low' | 'medium' | 'high' | 'critical';
+  priority?: 'low' | 'medium' | 'high' | 'critical' | number;
   layer?: string;
   tags?: string[];
   created_by?: string;
@@ -430,7 +430,7 @@ export interface AddConstraintParams {
 export interface GetConstraintsParams {
   category?: string;
   layer?: string;
-  priority?: 'low' | 'medium' | 'high' | 'critical';
+  priority?: 'low' | 'medium' | 'high' | 'critical' | number;
   tags?: string[];
   include_inactive?: boolean;
   limit?: number;

--- a/src/utils/action-specs/constraint-specs.ts
+++ b/src/utils/action-specs/constraint-specs.ts
@@ -19,7 +19,7 @@ export const CONSTRAINT_ACTION_SPECS: Record<string, ActionSpec> = {
       layer: 'business',
       tags: ['api', 'latency']
     },
-    hint: "Valid categories: performance, architecture, security, code-style. Valid priorities: low, medium, high, critical. Set active=false for draft constraints. NOTE: rationale is NOT supported - include it in tags or constraint_text if needed."
+    hint: "Valid categories: performance, architecture, security, code-style. Valid priorities: low, medium, high, critical (or 1-4). Set active=false for draft constraints. NOTE: rationale is NOT supported - include it in tags or constraint_text if needed."
   },
 
   get: {

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -43,13 +43,21 @@ export function validateStatus(status: string): 'active' | 'deprecated' | 'draft
 }
 
 /**
- * Validates priority string (low/medium/high/critical)
+ * Validates priority string or number (low/medium/high/critical or 1-4)
+ * Accepts numeric priorities for backward compatibility with TOML docs
  * @throws Error if priority is not valid
  */
-export function validatePriority(priority: string): 'low' | 'medium' | 'high' | 'critical' {
+export function validatePriority(priority: string | number): 'low' | 'medium' | 'high' | 'critical' {
+  // Accept numeric priorities (backward compat)
+  if (typeof priority === 'number') {
+    const numToStr: Record<number, string> = { 1: 'low', 2: 'medium', 3: 'high', 4: 'critical' };
+    const converted = numToStr[priority];
+    if (converted) return converted as 'low' | 'medium' | 'high' | 'critical';
+    throw new Error('Invalid priority number. Must be 1-4 (1=low, 2=medium, 3=high, 4=critical)');
+  }
   const validPriorities = ['low', 'medium', 'high', 'critical'];
   if (!validPriorities.includes(priority)) {
-    throw new Error(`Invalid priority. Must be one of: ${validPriorities.join(', ')}`);
+    throw new Error(`Invalid priority. Must be one of: ${validPriorities.join(', ')} (or 1-4)`);
   }
   return priority as 'low' | 'medium' | 'high' | 'critical';
 }


### PR DESCRIPTION
## Summary

- Extend `validatePriority()` to accept `string | number`, auto-converting numeric 1-4 to string equivalents
- Fix TOML help document: change priority from `type = "number"` to `type = "string"`, unify examples to use strings
- Fix false positive in `filter-test-output.js` when test names contain "Error"

## Test plan

- [x] `npx tsc` compiles successfully
- [x] `npm test` 573/573 all passing
- [x] pre-commit hook all checks passed
- [x] Verify in MCP Inspector that `constraint add` works with both `priority: 4` and `priority: "high"`