### PR TITLE
fix: resolve file watcher cross-platform compatibility issues

### DIFF
--- a/src/config/global-config.ts
+++ b/src/config/global-config.ts
@@ -9,6 +9,7 @@ import { readFileSync, existsSync, mkdirSync, writeFileSync, unlinkSync, readdir
 import { join, resolve } from 'path';
 import { homedir } from 'os';
 import { parse as parseTOML, stringify as stringifyTOML } from 'smol-toml';
+import { normalizeWindowsPath } from '../utils/path-normalize.js';
 
 // ============================================================================
 // Types
@@ -385,25 +386,8 @@ export function getSessionCachePath(projectPath: string): string {
     mkdirSync(cacheDir, { recursive: true });
   }
 
-  // Normalize path for cross-platform consistency
-  // - Handle Git Bash/MSYS2 paths (/c/Users → C:\Users) on Windows
-  // - Lowercase drive letter ensures consistent cache filename
-  // - On macOS/Linux, resolve() is sufficient (no drive letters)
-  let normalizedPath = projectPath;
-
-  // Convert Git Bash/MSYS2 paths (/c/Users/...) to Windows paths (C:\Users\...)
-  if (process.platform === 'win32' && /^\/[a-zA-Z]\//.test(normalizedPath)) {
-    const driveLetter = normalizedPath[1].toUpperCase();
-    normalizedPath = driveLetter + ':' + normalizedPath.slice(2).replace(/\//g, '\\');
-  }
-
-  // Resolve to absolute path
-  normalizedPath = resolve(normalizedPath);
-
-  // Lowercase drive letter for consistency
-  if (process.platform === 'win32' && /^[A-Z]:/.test(normalizedPath)) {
-    normalizedPath = normalizedPath[0].toLowerCase() + normalizedPath.slice(1);
-  }
+  // Normalize path for cross-platform consistency (Git Bash/MSYS2 conversion, drive letter)
+  const normalizedPath = normalizeWindowsPath(projectPath);
 
   // Create a safe filename from project path
   const safeName = normalizedPath
@@ -552,19 +536,8 @@ export function getPlanCachePath(projectPath: string): string {
     mkdirSync(cacheDir, { recursive: true });
   }
 
-  // Use same normalization as getSessionCachePath
-  let normalizedPath = projectPath;
-
-  if (process.platform === 'win32' && /^\/[a-zA-Z]\//.test(normalizedPath)) {
-    const driveLetter = normalizedPath[1].toUpperCase();
-    normalizedPath = driveLetter + ':' + normalizedPath.slice(2).replace(/\//g, '\\');
-  }
-
-  normalizedPath = resolve(normalizedPath);
-
-  if (process.platform === 'win32' && /^[A-Z]:/.test(normalizedPath)) {
-    normalizedPath = normalizedPath[0].toLowerCase() + normalizedPath.slice(1);
-  }
+  // Normalize path for cross-platform consistency (Git Bash/MSYS2 conversion, drive letter)
+  const normalizedPath = normalizeWindowsPath(projectPath);
 
   const safeName = normalizedPath
     .replace(/[^a-zA-Z0-9]/g, '_')

--- a/src/utils/path-normalize.ts
+++ b/src/utils/path-normalize.ts
@@ -1,0 +1,43 @@
+/**
+ * Path Normalization Utilities
+ *
+ * Cross-platform path normalization for Windows environments.
+ * Handles Git Bash/MSYS2 path conversion and drive letter consistency.
+ *
+ * @since v5.2.0
+ */
+
+import { resolve } from 'path';
+
+/**
+ * Normalize a path for Windows cross-platform consistency.
+ *
+ * Performs:
+ * 1. Git Bash/MSYS2 path conversion (/c/Users/... -> C:\Users\...)
+ * 2. Absolute path resolution via resolve()
+ * 3. Drive letter lowercase normalization
+ *
+ * On non-Windows platforms, only resolve() is applied.
+ *
+ * @param inputPath - Path to normalize
+ * @returns Normalized absolute path
+ */
+export function normalizeWindowsPath(inputPath: string): string {
+  let normalizedPath = inputPath;
+
+  // Convert Git Bash/MSYS2 paths (/c/Users/...) to Windows paths (C:\Users\...)
+  if (process.platform === 'win32' && /^\/[a-zA-Z]\//.test(normalizedPath)) {
+    const driveLetter = normalizedPath[1].toUpperCase();
+    normalizedPath = driveLetter + ':' + normalizedPath.slice(2).replace(/\//g, '\\');
+  }
+
+  // Resolve to absolute path
+  normalizedPath = resolve(normalizedPath);
+
+  // Lowercase drive letter for consistency
+  if (process.platform === 'win32' && /^[A-Z]:/.test(normalizedPath)) {
+    normalizedPath = normalizedPath[0].toLowerCase() + normalizedPath.slice(1);
+  }
+
+  return normalizedPath;
+}

--- a/src/watcher/base-watcher.ts
+++ b/src/watcher/base-watcher.ts
@@ -11,7 +11,7 @@
  */
 
 import chokidar, { FSWatcher } from 'chokidar';
-import { execSync } from 'child_process';
+import { detectEnvironment } from '../utils/environment-detector.js';
 import { debugLog } from '../utils/debug-logger.js';
 
 /**
@@ -48,34 +48,22 @@ export abstract class BaseWatcher {
   }
 
   /**
-   * Detect if running on WSL (Windows Subsystem for Linux)
-   */
-  protected isWSL(): boolean {
-    if (process.platform !== 'linux') {
-      return false;
-    }
-
-    try {
-      const result = execSync('uname -r', {
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'ignore'],
-      });
-      return (
-        result.toLowerCase().includes('microsoft') ||
-        result.toLowerCase().includes('wsl')
-      );
-    } catch {
-      return false;
-    }
-  }
-
-  /**
    * Initialize chokidar watcher with common options
    */
   protected initializeWatcher(options: WatcherOptions): FSWatcher {
-    const isWSL = this.isWSL();
+    const env = detectEnvironment();
+    const isWSL = env === 'wsl';
     if (isWSL) {
       debugLog('INFO', `${this.watcherName}: WSL detected`);
+    }
+
+    // WSL2 + Windows FS (/mnt/) requires polling because inotify doesn't work
+    const paths = Array.isArray(options.paths) ? options.paths : [options.paths];
+    const needsPolling = isWSL && paths.some(p => p.startsWith('/mnt/'));
+    const usePolling = options.usePolling ?? needsPolling;
+
+    if (needsPolling && options.usePolling === undefined) {
+      debugLog('INFO', `${this.watcherName}: Auto-enabling polling for WSL2 Windows FS`);
     }
 
     const watcherConfig: Parameters<typeof chokidar.watch>[1] = {
@@ -86,7 +74,7 @@ export abstract class BaseWatcher {
         stabilityThreshold: Math.max(options.debounceMs ?? this.debounceMs, 1000),
         pollInterval: 500,  // Reduced polling frequency to avoid duplicate events
       },
-      usePolling: options.usePolling ?? false,
+      usePolling,
       interval: options.pollInterval ?? 500,  // Match polling interval
     };
 


### PR DESCRIPTION
## Summary

- Unify WSL detection: replace base-watcher.ts `execSync('uname -r')` with `detectEnvironment()` from environment-detector.ts (reads `/proc/version`, no shell spawn)
- Auto-enable polling for WSL2 + Windows FS (`/mnt/`) where inotify doesn't work
- Extract duplicated path normalization code (27 lines x 2) into `normalizeWindowsPath()` utility

## Architecture Decisions

### Decision: watcher/wsl-detection-unification (single source of truth for WSL detection)

- `src/watcher/base-watcher.ts`: Removed `isWSL()` method (used `execSync('uname -r')`) and replaced with `detectEnvironment() === 'wsl'` from environment-detector.ts. The `/proc/version`-based approach is safer in CI/container environments where shell may not be available.

### Decision: watcher/wsl2-auto-polling (auto-handle inotify-incompatible environments)

- `src/watcher/base-watcher.ts`: When WSL is detected and watch paths start with `/mnt/`, automatically set `usePolling: true`. chokidar v4's WSL auto-detection only covers Linux FS, not Windows FS mounted at `/mnt/`.

### Decision: utils/path-normalize-utility (DRY path conversion logic)

- `src/utils/path-normalize.ts`: New utility. Consolidates Git Bash/MSYS2 path conversion (`/c/Users/...` -> `C:\Users\...`), `resolve()`, and drive letter normalization into one function.
- `src/config/global-config.ts`: Replaced identical 17-line path normalization blocks in `getSessionCachePath()` and `getPlanCachePath()` with `normalizeWindowsPath()` calls.

### Constraint: WSL detection must use environment-detector.ts

- `src/watcher/base-watcher.ts`: Shell-based WSL detection (`execSync`) is prohibited. All WSL detection must use the `/proc/version`-based `detectEnvironment()` for safety and consistency.

## Other Changes

None.

## Test Plan

- [x] `npx tsc` — no compile errors
- [x] `npm run test:unit` — all 291 tests pass
- [x] Verified no `execSync` / `child_process` imports in base-watcher.ts
- [x] Code review: WSL + `/mnt/` auto-polling logic confirmed