### PR TITLE
feat(grok): Grok Build support v5.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 .serena
 CLAUDE.md
 
+# Cursor MCP tool descriptors (auto-generated)
+mcps/
+
 # Dependencies
 node_modules/
 
@@ -48,6 +51,10 @@ coverage/
 # Temporary files
 tmp/
 temp/
+
+# indexion (third-party CLI, not part of sqlew)
+.indexion.toml
+.indexion/
 
 # Test and documentation files (phase-specific)
 PHASE*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [5.2.0] - 2026-06-11
+
+### Added
+
+**Grok Build support (sqlew-plugin v5.2.0)**
+
+Unified Plan-to-ADR support for Grok Build alongside Claude Code via a single sqlew-plugin install. No separate sqlew-grok adapter required.
+
+- **`normalizeHookInput()`** — Translates Grok hook payloads (`hookEventName`, `toolName`, `sessionId`, `workspaceRoot`) to canonical Claude-shaped `HookInput`. Claude payloads pass through unchanged.
+- **`computeGrokPlanPath()`** — Resolves per-session plan file at `~/.grok/sessions/<encodeURIComponent(cwd)>/<sessionId>/plan.md`.
+- **`injectGrokPlanTemplate()`** — Appends Decision/Constraint template to `plan.md` on `enter_plan_mode` (file side-effect). Grok ignores passive hook stdout; skills auto-invocation is unreliable.
+- **`GROK_WORKSPACE_ROOT`** — Added to `determineProjectRoot()` for MCP server project root resolution.
+- **Grok `sendBlock()` compat** — PreToolUse deny hooks emit `{"decision":"deny","reason":"..."}` on stdout for Grok (in addition to exit 2 + stderr for Claude Code).
+- **Unit tests** — `grok-hook-normalization.test.ts`, `grok-plan-template-injection.test.ts`.
+
+### Changed
+
+- **`on-prompt`** — Early return for Grok client (`UserPromptSubmit` stdout is ignored on Grok).
+- **`on-exit-plan` / `track-plan`** — Record `CurrentPlanInfo.plan_path` for Grok; always re-resolve from `session_id` on exit.
+- **`plan-processor`** — Prefer explicit `plan_path` over legacy Claude global plans resolver.
+- **`docs/HOOKS_GUIDE.md`** — Replaced sqlew-grok adapter instructions with `grok plugin install sqlew-io/sqlew-plugin --trust` workflow.
+
+### Plugin Changes (sqlew-plugin v5.2.0)
+
+- Hook matchers: `enter_plan_mode` / `exit_plan_mode` alongside Claude tool names
+- Skills: Grok-specific plan mode guidance (`sqlew-plan-guidance`, `sqlew-decision-format`)
+
+---
+
 ## [5.1.0] - 2026-03-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ The plugin automatically configures MCP server, Skills (Plan Mode guidance), and
 
 See [sqlew-codex](https://github.com/sqlew-io/sqlew-codex) for Codex CLI integration.
 
+#### Grok Build (Plugin)
+
+```bash
+npm install -g sqlew
+grok plugin install sqlew-io/sqlew-plugin --trust
+grok plugin update
+```
+
+The plugin configures MCP server, Skills (plan mode guidance), and Hooks (automatic decision capture on `exit_plan_mode`). See [Hooks Guide](docs/HOOKS_GUIDE.md) for setup details and caveats (do not duplicate hooks in `~/.grok/hooks/` or `config.toml`).
+
 #### Manual
 
 Add to `.mcp.json` in your project root:
@@ -86,7 +96,7 @@ No special commands needed — just plan your work normally, and sqlew captures 
 - **Fast Queries** — 2-50ms retrieval via SQL, even with thousands of decisions
 - **Duplicate Detection** — Three-tier similarity scoring (0-100) prevents redundant decisions
 - **Constraint Tracking** — Architectural rules and principles as first-class entities
-- **Auto-Capture** — Hooks automatically record decisions from Plan Mode (Claude Code plugin)
+- **Auto-Capture** — Hooks automatically record decisions from Plan Mode (Claude Code and Grok Build via sqlew-plugin)
 - **Multi-Database** — SQLite (default), PostgreSQL, MySQL/MariaDB, or Cloud
 - **Git Worktree Ready** — Each worktree shares the same context database
 
@@ -142,7 +152,7 @@ name = "your-project-name"
 |-------|-------------|
 | [ADR Concepts](docs/ADR_CONCEPTS.md) | Architecture Decision Records explained |
 | [Configuration](docs/CONFIGURATION.md) | Config file setup, database options |
-| [Hooks Guide](docs/HOOKS_GUIDE.md) | Claude Code Hooks integration |
+| [Hooks Guide](docs/HOOKS_GUIDE.md) | Claude Code, Codex, and Grok Build integration |
 | [Cross Database](docs/CROSS_DATABASE.md) | Multi-database support |
 | [CLI Usage](docs/CLI_USAGE.md) | Database migration, export/import |
 
@@ -163,16 +173,15 @@ Support development via [GitHub Sponsors](https://github.com/sponsors/sqlew-io).
 
 ## Version
 
-Current version: **5.0.8**
+Current version: **5.2.0**
 
 See [CHANGELOG.md](CHANGELOG.md) for release history.
 
-**What's New in v5.0.8:**
+**What's New in v5.2.0:**
 
-- **PR ADR enforcement** — PreToolUse Hook blocks `gh pr create` without ADR markers, file-grouped format
-- **Codex CLI support** — Works beyond Claude Code via [sqlew-codex](https://github.com/sqlew-io/sqlew-codex)
-- **Plugin-first architecture** — Simplified setup via sqlew-plugin
-- **Cloud backend** — Connect to [sqlew.io](https://sqlew.io) for team-shared decisions
+- **Grok Build support** — Plan-to-ADR via [sqlew-plugin](https://github.com/sqlew-io/sqlew-plugin) (`grok plugin install sqlew-io/sqlew-plugin --trust`)
+- **Grok plan.md injection** — Decision/Constraint template appended on `enter_plan_mode`
+- **Hook normalization** — Single CLI hook handlers work under both Claude Code and Grok Build
 
 ## License
 

--- a/docs/HOOKS_GUIDE.md
+++ b/docs/HOOKS_GUIDE.md
@@ -58,8 +58,15 @@ No separate adapter is required.
 
 ```bash
 npm i -g sqlew
-grok plugin install /path/to/sqlew-plugin --trust
+grok plugin install sqlew-io/sqlew-plugin --trust
 grok plugin update
+```
+
+For local development, install from a cloned directory instead:
+
+```bash
+git clone https://github.com/sqlew-io/sqlew-plugin.git
+grok plugin install ./sqlew-plugin --trust
 ```
 
 Verify installation:

--- a/docs/HOOKS_GUIDE.md
+++ b/docs/HOOKS_GUIDE.md
@@ -53,29 +53,42 @@ Source: https://github.com/sqlew-io/sqlew-codex
 
 ## Grok Build
 
+sqlew-plugin provides unified support for Claude Code and Grok Build (v5.2+).
+No separate adapter is required.
+
 ```bash
-git clone https://github.com/sqlew-io/sqlew-grok.git
-# Place the required files under ~/.grok/hooks/ etc. (see sqlew-grok/README.md for details)
+npm i -g sqlew
+grok plugin install /path/to/sqlew-plugin --trust
+grok plugin update
 ```
 
-See `hooks/sqlew-grok.json` in the sqlew-grok repository for an example hook definition for Grok Build.
+Verify installation:
 
-**Note**: sqlew-grok is under development. At this time, minimal extensions on the sqlew core side (v5.2+ expected) are required.
+```bash
+grok plugin list          # sqlew enabled + trusted
+grok inspect              # hooks, MCP, skills visible
+```
 
-Source: https://github.com/sqlew-io/sqlew-grok
+**Important**:
+- Do NOT register sqlew hooks in `~/.grok/hooks/` (causes double-firing with plugin hooks)
+- Do NOT add `[mcp_servers.sqlew]` to `~/.grok/config.toml` (plugin `.mcp.json` handles MCP)
+- Plan mode guidance uses plugin skills (`sqlew-plan-guidance`, `sqlew-decision-format`), not hook injection
+- Plan-to-ADR extracts `### 📌 Decision:` / `### 🚫 Constraint:` from `plan.md` on `exit_plan_mode`
+
+Source: https://github.com/sqlew-io/sqlew-plugin
 
 ## What Gets Configured
 
 | Feature | Claude Code | Codex | Grok Build |
 |---------|-------------|-------|------------|
-| MCP server | Auto-configured | Manual (config.toml) | Manual (hooks + MCP) |
-| Plan-to-ADR | Skills + Hooks | Skills + System prompt | Hooks (in development) |
-| PR enrichment | Skill (sqlew-pr-adr) | Skill (sqlew-pr-adr) | Planned |
-| Decision format guidance | Skill (sqlew-decision-format) | Skill (sqlew-decision-format) | Planned |
+| MCP server | Auto-configured | Manual (config.toml) | Plugin `.mcp.json` |
+| Plan-to-ADR | Skills + Hooks | Skills + System prompt | Skills + Hooks |
+| PR enrichment | Skill (sqlew-pr-adr) | Skill (sqlew-pr-adr) | Skill (sqlew-pr-adr) |
+| Decision format guidance | Skill (sqlew-decision-format) | Skill (sqlew-decision-format) | Skill (sqlew-decision-format) |
 
 ## Version History
 
-- **v5.2+ (planned)**: Start of Grok Build support (sqlew-grok adapter)
+- **v5.2.0**: Grok Build support via sqlew-plugin (hook normalization, Grok plan path, skills-based plan guidance)
 - **v5.0.0**: Plugin-first architecture (sqlew-plugin for Claude Code, sqlew-codex for Codex)
 - **v4.3.0**: Plan-to-ADR - Automatic ADR from Plan Mode
 - **v4.1.0**: Initial Claude Code Hooks integration

--- a/docs/HOOKS_GUIDE.md
+++ b/docs/HOOKS_GUIDE.md
@@ -51,17 +51,31 @@ To uninstall, remove the copied skill directories and config entries.
 
 Source: https://github.com/sqlew-io/sqlew-codex
 
+## Grok Build
+
+```bash
+git clone https://github.com/sqlew-io/sqlew-grok.git
+# Place the required files under ~/.grok/hooks/ etc. (see sqlew-grok/README.md for details)
+```
+
+See `hooks/sqlew-grok.json` in the sqlew-grok repository for an example hook definition for Grok Build.
+
+**Note**: sqlew-grok is under development. At this time, minimal extensions on the sqlew core side (v5.2+ expected) are required.
+
+Source: https://github.com/sqlew-io/sqlew-grok
+
 ## What Gets Configured
 
-| Feature | Claude Code | Codex |
-|---------|-------------|-------|
-| MCP server | Auto-configured | Manual (config.toml) |
-| Plan-to-ADR | Skills + Hooks | Skills + System prompt |
-| PR enrichment | Skill (sqlew-pr-adr) | Skill (sqlew-pr-adr) |
-| Decision format guidance | Skill (sqlew-decision-format) | Skill (sqlew-decision-format) |
+| Feature | Claude Code | Codex | Grok Build |
+|---------|-------------|-------|------------|
+| MCP server | Auto-configured | Manual (config.toml) | Manual (hooks + MCP) |
+| Plan-to-ADR | Skills + Hooks | Skills + System prompt | Hooks (in development) |
+| PR enrichment | Skill (sqlew-pr-adr) | Skill (sqlew-pr-adr) | Planned |
+| Decision format guidance | Skill (sqlew-decision-format) | Skill (sqlew-decision-format) | Planned |
 
 ## Version History
 
+- **v5.2+ (planned)**: Start of Grok Build support (sqlew-grok adapter)
 - **v5.0.0**: Plugin-first architecture (sqlew-plugin for Claude Code, sqlew-codex for Codex)
 - **v4.3.0**: Plan-to-ADR - Automatic ADR from Plan Mode
 - **v4.1.0**: Initial Claude Code Hooks integration

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "sqlew",
   "display_name": "sqlew - Context Manager for AI Agents",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Token-efficient context management for AI coding agents. Record architectural decisions, constraints, and maintain project knowledge across sessions. Supports SQLite local storage and sqlew.io cloud backend.",
   "author": {
     "name": "sqlew.io",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlew",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlew",
-      "version": "5.1.0",
+      "version": "5.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlew",
-  "description": "Automated ADR (Architecture Decision Records) for Claude Code - MCP server with SQL-backed decision repository",
+  "description": "Automated ADR (Architecture Decision Records) for AI Coding Agents - MCP server with SQL-backed decision repository",
   "version": "5.1.0",
   "main": "dist/index.js",
   "type": "module",
@@ -35,7 +35,7 @@
     "migrate:rollback": "npm run knex migrate:rollback",
     "test:backend": "node --test --test-force-exit --import tsx \"src/tests/backend/**/*.test.ts\" | node scripts/filter-test-output.js",
     "test:backend:verbose": "node --test --test-force-exit --import tsx \"src/tests/backend/**/*.test.ts\"",
-"migrate:status": "npm run knex migrate:status"
+    "migrate:status": "npm run knex migrate:status"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sqlew",
   "description": "Automated ADR (Architecture Decision Records) for AI Coding Agents - MCP server with SQL-backed decision repository",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "main": "dist/index.js",
   "type": "module",
   "bin": {

--- a/src/cli/hooks/on-exit-plan.ts
+++ b/src/cli/hooks/on-exit-plan.ts
@@ -11,7 +11,9 @@
  * @modified v4.2.5 - Refactored to use plan-processor.ts (DRY)
  */
 
-import { readStdinJson, sendContinue, sendPostToolUseContext, getProjectPath } from './stdin-parser.js';
+import { randomUUID } from 'crypto';
+import { readStdinJson, sendContinue, sendPostToolUseContext, getProjectPath, computeGrokPlanPath } from './stdin-parser.js';
+import { loadCurrentPlan, saveCurrentPlan, type CurrentPlanInfo } from '../../config/global-config.js';
 import { processPlanPatterns } from './plan-processor.js';
 
 // ============================================================================
@@ -38,6 +40,30 @@ export async function onExitPlanCommand(): Promise<void> {
     if (!projectPath) {
       sendContinue();
       return;
+    }
+
+    // Grok Build: the per-session plan lives at ~/.grok/sessions/<enc(cwd)>/<sessionId>/plan.md.
+    // The exit hook's session_id is authoritative (each Grok session has its own plan.md), so
+    // ALWAYS resolve the path from it here — never trust a stored plan_path, which may be stale
+    // from a previous session and would make processPlanPatterns read the wrong/missing file.
+    // When the stored info belongs to a different session we reset it as a new plan; when it's
+    // the same session we preserve plan_id/recorded so dedup still works.
+    if (input.client === 'grok' && input.session_id) {
+      const planPath = computeGrokPlanPath(projectPath, input.session_id);
+      if (planPath) {
+        const existing = loadCurrentPlan(projectPath);
+        const sameSession = existing?.plan_path === planPath;
+        const planInfo: CurrentPlanInfo = {
+          plan_id: sameSession && existing ? existing.plan_id : randomUUID(),
+          plan_file: 'plan.md',
+          plan_path: planPath,
+          plan_updated_at: new Date().toISOString(),
+          recorded: sameSession ? (existing?.recorded ?? false) : false,
+          decision_pending: sameSession ? (existing?.decision_pending ?? true) : true,
+          enforcement_shown_at: sameSession ? existing?.enforcement_shown_at : undefined,
+        };
+        saveCurrentPlan(projectPath, planInfo);
+      }
     }
 
     // Delegate to shared processor

--- a/src/cli/hooks/on-exit-plan.ts
+++ b/src/cli/hooks/on-exit-plan.ts
@@ -15,6 +15,7 @@ import { randomUUID } from 'crypto';
 import { readStdinJson, sendContinue, sendPostToolUseContext, getProjectPath, computeGrokPlanPath } from './stdin-parser.js';
 import { loadCurrentPlan, saveCurrentPlan, type CurrentPlanInfo } from '../../config/global-config.js';
 import { processPlanPatterns } from './plan-processor.js';
+import { debugLog } from '../../utils/debug-logger.js';
 
 // ============================================================================
 // Main Entry Point
@@ -38,9 +39,20 @@ export async function onExitPlanCommand(): Promise<void> {
 
     const projectPath = getProjectPath(input);
     if (!projectPath) {
+      debugLog('WARN', '[on-exit-plan] No project path', {
+        client: input.client,
+        session_id: input.session_id,
+        cwd: input.cwd,
+      });
       sendContinue();
       return;
     }
+
+    debugLog('DEBUG', '[on-exit-plan] Processing exit', {
+      client: input.client,
+      session_id: input.session_id,
+      projectPath,
+    });
 
     // Grok Build: the per-session plan lives at ~/.grok/sessions/<enc(cwd)>/<sessionId>/plan.md.
     // The exit hook's session_id is authoritative (each Grok session has its own plan.md), so
@@ -68,6 +80,12 @@ export async function onExitPlanCommand(): Promise<void> {
 
     // Delegate to shared processor
     const result = processPlanPatterns(projectPath);
+
+    debugLog('DEBUG', '[on-exit-plan] Result', {
+      processed: result.processed,
+      skipReason: result.skipReason,
+      projectPath,
+    });
 
     if (!result.processed) {
       // Map skip reasons to user-friendly messages

--- a/src/cli/hooks/on-prompt.ts
+++ b/src/cli/hooks/on-prompt.ts
@@ -79,6 +79,12 @@ export async function onPromptCommand(): Promise<void> {
   try {
     const input = await readStdinJson();
 
+    // Grok Build: UserPromptSubmit is a passive hook — stdout is ignored.
+    // Plan mode guidance is delivered via plugin skills instead.
+    if (input.client === 'grok') {
+      return;
+    }
+
     if (!isPlanMode(input)) {
       // Non-plan mode: output nothing (exit 0 = allow, no context injection)
       return;

--- a/src/cli/hooks/plan-processor.ts
+++ b/src/cli/hooks/plan-processor.ts
@@ -13,6 +13,7 @@
 import { readFileSync, existsSync } from 'fs';
 import { loadCurrentPlan, saveCurrentPlan, type CurrentPlanInfo } from '../../config/global-config.js';
 import { enqueueDecisionCreate, enqueueConstraintCreate, enqueueDecisionContextCreate } from '../../utils/hook-queue.js';
+import { debugLog } from '../../utils/debug-logger.js';
 import {
   extractPatternsFromPlan,
   hasPatterns,
@@ -63,6 +64,7 @@ export function processPlanPatterns(projectPath: string): ProcessPlanResult {
   // Load current plan info
   const planInfo = loadCurrentPlan(projectPath);
   if (!planInfo?.plan_file) {
+    debugLog('DEBUG', '[plan-processor] Skip: no_active_plan', { projectPath });
     return { processed: false, skipReason: 'no_active_plan' };
   }
 
@@ -80,6 +82,11 @@ export function processPlanPatterns(projectPath: string): ProcessPlanResult {
     planPath = resolvePlanPath(planInfo.plan_file);
   }
   if (!planPath) {
+    debugLog('DEBUG', '[plan-processor] Skip: plan_file_not_found', {
+      projectPath,
+      plan_path: planInfo.plan_path,
+      plan_file: planInfo.plan_file,
+    });
     return { processed: false, skipReason: 'plan_file_not_found' };
   }
 

--- a/src/cli/hooks/plan-processor.ts
+++ b/src/cli/hooks/plan-processor.ts
@@ -10,7 +10,7 @@
  * @since v4.2.5
  */
 
-import { readFileSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
 import { loadCurrentPlan, saveCurrentPlan, type CurrentPlanInfo } from '../../config/global-config.js';
 import { enqueueDecisionCreate, enqueueConstraintCreate, enqueueDecisionContextCreate } from '../../utils/hook-queue.js';
 import {
@@ -72,7 +72,13 @@ export function processPlanPatterns(projectPath: string): ProcessPlanResult {
   }
 
   // Resolve plan file path
-  const planPath = resolvePlanPath(planInfo.plan_file);
+  // Prefer explicit plan_path (Grok Build + future envs) over legacy plan_file + GLOBAL_PLANS_DIR resolution (Claude)
+  let planPath: string | null = null;
+  if (planInfo.plan_path && existsSync(planInfo.plan_path)) {
+    planPath = planInfo.plan_path;
+  } else {
+    planPath = resolvePlanPath(planInfo.plan_file);
+  }
   if (!planPath) {
     return { processed: false, skipReason: 'plan_file_not_found' };
   }

--- a/src/cli/hooks/stdin-parser.ts
+++ b/src/cli/hooks/stdin-parser.ts
@@ -7,6 +7,13 @@
  * @since v4.1.0
  */
 
+import { existsSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+
+import { loadCurrentPlan } from '../../config/global-config.js';
+import { resolvePlanPath } from './plan-pattern-extractor.js';
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -83,6 +90,8 @@ export interface HookInput {
   source?: 'startup' | 'resume' | 'clear' | 'compact';
   /** SessionEnd reason: clear | logout | prompt_input_exit | other */
   reason?: 'clear' | 'logout' | 'prompt_input_exit' | 'other';
+  /** Originating client, set by normalizeHookInput() (e.g., 'grok'). undefined = Claude/native. */
+  client?: 'grok' | 'claude';
 }
 
 /**
@@ -132,6 +141,118 @@ export interface HookOutput {
 }
 
 // ============================================================================
+// Cross-agent normalization (Claude / Grok Build / future)
+// ============================================================================
+
+/**
+ * Grok Build event names (snake_case) → Claude canonical event names (PascalCase).
+ * Grok sends e.g. "pre_tool_use"; Claude sends "PreToolUse".
+ */
+const GROK_EVENT_MAP: Record<string, HookInput['hook_event_name']> = {
+  pre_tool_use: 'PreToolUse',
+  post_tool_use: 'PostToolUse',
+  post_tool_use_failure: 'PostToolUse',
+  user_prompt_submit: 'UserPromptSubmit',
+  session_start: 'SessionStart',
+  session_end: 'SessionEnd',
+  stop: 'Stop',
+  notification: 'Notification',
+  pre_compact: 'PreCompact',
+};
+
+/**
+ * Grok Build tool names → Claude canonical tool names.
+ * Only the names sqlew's hook handlers branch on need mapping; unknown names pass through.
+ */
+const GROK_TOOL_MAP: Record<string, string> = {
+  enter_plan_mode: 'EnterPlanMode',
+  exit_plan_mode: 'ExitPlanMode',
+  search_replace: 'Edit',
+  run_terminal_cmd: 'Bash',
+  read_file: 'Read',
+};
+
+/**
+ * Normalize a raw hook payload into the canonical (Claude-shaped) HookInput.
+ *
+ * Claude Code payloads already use snake_case keys + PascalCase event/tool names,
+ * so they pass through unchanged (backward compatible). Grok Build payloads use
+ * camelCase keys (`hookEventName`/`toolName`/`toolInput`/`sessionId`) and snake_case
+ * event/tool values, which are translated here so every downstream handler keeps
+ * working without modification.
+ *
+ * @param raw - Parsed JSON from stdin (any shape)
+ * @returns Canonical HookInput
+ */
+export function normalizeHookInput(raw: unknown): HookInput {
+  if (!raw || typeof raw !== 'object') {
+    raw = {};
+  }
+  const r = raw as Record<string, unknown>;
+
+  const isGrok = !!(
+    r.hookEventName ||
+    r.toolName ||
+    r.toolInput ||
+    r.workspaceRoot ||
+    r.sessionId ||
+    process.env.GROK_HOOK_EVENT ||
+    process.env.GROK_WORKSPACE_ROOT
+  );
+
+  // Claude / native: pass through unchanged
+  if (!isGrok) {
+    return r as HookInput;
+  }
+
+  const rawEvent = (r.hookEventName || r.hook_event_name || process.env.GROK_HOOK_EVENT) as
+    | string
+    | undefined;
+  const rawTool = (r.toolName || r.tool_name) as string | undefined;
+
+  return {
+    ...(r as HookInput),
+    client: 'grok',
+    hook_event_name: rawEvent
+      ? GROK_EVENT_MAP[rawEvent] || (rawEvent as HookInput['hook_event_name'])
+      : (r.hook_event_name as HookInput['hook_event_name']),
+    tool_name: rawTool ? GROK_TOOL_MAP[rawTool] || rawTool : (r.tool_name as string | undefined),
+    tool_input: (r.toolInput || r.tool_input) as ToolInput | undefined,
+    session_id: (r.sessionId || r.session_id || process.env.GROK_SESSION_ID) as string | undefined,
+    // Grok provides cwd + workspaceRoot (equal); fall back to env for empty-stdin events.
+    cwd: (r.cwd || r.workspaceRoot || process.env.GROK_WORKSPACE_ROOT) as string | undefined,
+  };
+}
+
+/**
+ * Build the absolute path to a Grok Build session plan file.
+ *
+ * Grok stores per-session plans at:
+ *   ~/.grok/sessions/<encodeURIComponent(workspaceRoot)>/<sessionId>/plan.md
+ *
+ * IMPORTANT: encodeURIComponent is applied to the RAW workspace path string
+ * (backslashes included on Windows → `C:\...` becomes `C%3A%5C...`), matching
+ * the directory names Grok actually creates. Do not slash-normalize beforehand.
+ *
+ * @param workspaceRoot - Grok workspace root (cwd / workspaceRoot)
+ * @param sessionId - Grok session id (UUID-like; sanitized to prevent path traversal)
+ * @returns Absolute path to the session's plan.md, or null if sessionId is invalid
+ */
+export function computeGrokPlanPath(workspaceRoot: string, sessionId: string): string | null {
+  // Sanitize sessionId: it is interpolated into a filesystem path, so restrict it to
+  // the characters a real Grok session id uses (UUID: hex + hyphen). This blocks any
+  // path-traversal payload (`..`, separators) from escaping ~/.grok/sessions/.
+  if (!sessionId || !/^[A-Za-z0-9_-]+$/.test(sessionId)) {
+    return null;
+  }
+  // encodeURIComponent encodes every path separator in workspaceRoot, so it collapses
+  // to a single safe path segment (no traversal possible from the workspace part), and
+  // sessionId is allowlisted above — both inputs are validated before this join.
+  // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
+  return join(homedir(), '.grok', 'sessions', encodeURIComponent(workspaceRoot), sessionId, 'plan.md');
+}
+
+// ============================================================================
 // Parsing
 // ============================================================================
 
@@ -159,14 +280,14 @@ export async function readStdinJson(): Promise<HookInput> {
     // Parse when stdin closes
     process.stdin.on('end', () => {
       if (!data.trim()) {
-        // Empty stdin - return empty object
-        resolve({});
+        // Empty stdin - still normalize so env-based context (Grok GROK_* vars) is picked up
+        resolve(normalizeHookInput({}));
         return;
       }
 
       try {
-        const parsed = JSON.parse(data) as HookInput;
-        resolve(parsed);
+        const parsed = JSON.parse(data);
+        resolve(normalizeHookInput(parsed));
       } catch (error) {
         reject(new Error(`Invalid JSON input: ${error instanceof Error ? error.message : String(error)}`));
       }
@@ -276,6 +397,16 @@ export function sendUpdatedInput(originalInput: ToolInput, modifications: Partia
 export function isPlanMode(input: HookInput): boolean {
   // Claude Code
   if (input.permission_mode === 'plan') return true;
+
+  // Grok Build: plan mode is signaled via the enter_plan_mode / exit_plan_mode tools
+  // (no permission_mode field). The actual "active" state is best detected by the
+  // presence of a tracked plan for the project + tool context, but for simple
+  // enforcement we also accept explicit tool names in the current hook payload.
+  const tool = input.tool_name;
+  if (tool === 'enter_plan_mode' || tool === 'exit_plan_mode') {
+    return true;
+  }
+
   // Future: Codex, Cursor, etc.
   return false;
 }
@@ -332,7 +463,29 @@ export function areAllTodosCompleted(input: HookInput): boolean {
  * @returns Project path or undefined
  */
 export function getProjectPath(input: HookInput): string | undefined {
-  return input.cwd || process.env.CLAUDE_PROJECT_DIR;
+  return input.cwd || process.env.CLAUDE_PROJECT_DIR || process.env.GROK_WORKSPACE_ROOT;
+}
+
+/**
+ * Returns the best available absolute path to the currently tracked plan file.
+ *
+ * Priority:
+ * 1. Explicit plan_path stored in CurrentPlanInfo (Grok Build, future envs)
+ * 2. Resolved via legacy plan_file + environment-specific resolver (Claude)
+ *
+ * This is the function external adapters (sqlew-grok etc.) should prefer over
+ * manually calling resolvePlanPath.
+ */
+export function getActivePlanFilePath(projectPath: string): string | null {
+  const info = loadCurrentPlan(projectPath);
+  if (!info) return null;
+
+  if (info.plan_path && existsSync(info.plan_path)) {
+    return info.plan_path;
+  }
+
+  // Fallback to legacy resolution (Claude global plans dir)
+  return resolvePlanPath(info.plan_file);
 }
 
 /**

--- a/src/cli/hooks/stdin-parser.ts
+++ b/src/cli/hooks/stdin-parser.ts
@@ -354,6 +354,10 @@ export function sendPostToolUseContext(additionalContext: string): void {
  * @param reason - Reason for blocking
  */
 export function sendBlock(reason: string): void {
+  // Grok Build: PreToolUse hooks deliver reason via stdout deny JSON (stderr is not shown).
+  if (process.env.GROK_HOOK_EVENT || process.env.GROK_WORKSPACE_ROOT) {
+    console.log(JSON.stringify({ decision: 'deny', reason }));
+  }
   console.error(reason);
   process.exit(2);
 }

--- a/src/cli/hooks/track-plan.ts
+++ b/src/cli/hooks/track-plan.ts
@@ -28,8 +28,10 @@ import {
   clearCurrentPlan,
   type CurrentPlanInfo,
 } from '../../config/global-config.js';
-import { existsSync, readFileSync } from 'fs';
-import { resolve } from 'path';
+import { existsSync, readFileSync, writeFileSync, appendFileSync, mkdirSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { hasPatterns } from './plan-pattern-extractor.js';
+import { debugLog } from '../../utils/debug-logger.js';
 
 // ============================================================================
 // Template Constants
@@ -55,6 +57,46 @@ const PLAN_TEMPLATE = `
 
 ---
 `.trim();
+
+/** Marker heading written with PLAN_TEMPLATE; used to avoid duplicate injection. */
+export const PLAN_TEMPLATE_MARKER = '## 📝 Decision/Constraint Recording';
+
+/**
+ * Append Decision/Constraint template to a Grok Build plan.md (file side-effect).
+ *
+ * Grok ignores passive/PreToolUse stdout context injection, so we write directly
+ * to plan.md on enter_plan_mode. Skips when the template marker or real patterns
+ * are already present.
+ *
+ * @param planPath - Absolute path to ~/.grok/sessions/.../plan.md
+ * @returns true if template was written or appended
+ */
+export function injectGrokPlanTemplate(planPath: string): boolean {
+  const planDir = dirname(planPath);
+  if (!existsSync(planDir)) {
+    mkdirSync(planDir, { recursive: true });
+  }
+
+  if (!existsSync(planPath)) {
+    writeFileSync(planPath, `${PLAN_TEMPLATE}\n`, 'utf-8');
+    debugLog('DEBUG', '[track-plan] Created Grok plan.md with template', { planPath });
+    return true;
+  }
+
+  const content = readFileSync(planPath, 'utf-8');
+  if (content.includes(PLAN_TEMPLATE_MARKER) || hasPatterns(content)) {
+    debugLog('DEBUG', '[track-plan] Skipped Grok template injection', {
+      planPath,
+      hasMarker: content.includes(PLAN_TEMPLATE_MARKER),
+      hasPatterns: hasPatterns(content),
+    });
+    return false;
+  }
+
+  appendFileSync(planPath, `\n\n${PLAN_TEMPLATE}\n`, 'utf-8');
+  debugLog('DEBUG', '[track-plan] Appended template to Grok plan.md', { planPath });
+  return true;
+}
 
 // ============================================================================
 // Main Entry Point
@@ -94,6 +136,7 @@ export async function trackPlanCommand(): Promise<void> {
               decision_pending: true,
             };
             saveCurrentPlan(projectPath, planInfo);
+            injectGrokPlanTemplate(planPath);
           }
         }
       }

--- a/src/cli/hooks/track-plan.ts
+++ b/src/cli/hooks/track-plan.ts
@@ -17,7 +17,8 @@
  * @modified v4.2.3 - Added template injection on new plan creation
  */
 
-import { readStdinJson, sendContinue, isPlanFile, getProjectPath } from './stdin-parser.js';
+import { randomUUID } from 'crypto';
+import { readStdinJson, sendContinue, isPlanFile, getProjectPath, computeGrokPlanPath } from './stdin-parser.js';
 import { PLAN_MODE_ENFORCEMENT } from './on-prompt.js';
 import { extractPlanFileName, parseFrontmatter, generatePlanId, getPlanId } from './plan-id-utils.js';
 import {
@@ -78,6 +79,23 @@ export async function trackPlanCommand(): Promise<void> {
         // Clear old plan cache to prevent stale data on "clear context" approval
         clearPlanCache(projectPath);
         clearCurrentPlan(projectPath);
+
+        // Grok Build: pre-record the per-session plan.md path now (we have the sessionId).
+        // This keeps the cache warm; on-exit-plan also recomputes defensively if this is missed.
+        if (input.client === 'grok' && input.session_id) {
+          const planPath = computeGrokPlanPath(projectPath, input.session_id);
+          if (planPath) {
+            const planInfo: CurrentPlanInfo = {
+              plan_id: randomUUID(),
+              plan_file: 'plan.md',
+              plan_path: planPath,
+              plan_updated_at: new Date().toISOString(),
+              recorded: false,
+              decision_pending: true,
+            };
+            saveCurrentPlan(projectPath, planInfo);
+          }
+        }
       }
       sendContinue(PLAN_MODE_ENFORCEMENT);
       return;

--- a/src/config/global-config.ts
+++ b/src/config/global-config.ts
@@ -361,8 +361,14 @@ export function saveGlobalConfig(config: GlobalConfig): void {
 export interface CurrentPlanInfo {
   /** Unique plan ID (UUID) */
   plan_id: string;
-  /** Plan file name (e.g., "rippling-spinning-eagle.md") */
+  /** Plan file name (e.g., "rippling-spinning-eagle.md") — legacy, for Claude global plans */
   plan_file: string;
+  /**
+   * Absolute path to the actual plan file (preferred when set).
+   * Used by Grok Build (per-session plan.md) and future environments.
+   * When present, extraction logic should use this instead of resolving via plan_file + GLOBAL_PLANS_DIR.
+   */
+  plan_path?: string;
   /** Plan file last updated timestamp (ISO 8601) */
   plan_updated_at: string;
   /** Whether decision has been recorded for this plan */

--- a/src/database/migrations/v4/20251126000001_v4_migrate_data.ts
+++ b/src/database/migrations/v4/20251126000001_v4_migrate_data.ts
@@ -281,7 +281,8 @@ export async function up(knex: Knex): Promise<void> {
       'key_id', 'project_id', 'value', 'layer_id', 'version', 'status', 'ts'
     ]);
   } else {
-    // Legacy v3 schemas: t_decisions に project_id が存在しないため、固定値 1 を付与して移行する
+    // Legacy v3 schemas: t_decisions does not have a project_id column,
+    // so we assign a fixed value of 1 during migration.
     const hasTDecisions = await knex.schema.hasTable('t_decisions');
     if (!hasTDecisions) {
       console.error('  ⚠️ t_decisions does not exist, skipping');

--- a/src/tests/unit/hooks/grok-hook-normalization.test.ts
+++ b/src/tests/unit/hooks/grok-hook-normalization.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Grok Build Hook Normalization Unit Tests
+ *
+ * Tests normalizeHookInput() and computeGrokPlanPath() for Grok Build compatibility.
+ *
+ * @since v5.2.0
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { homedir } from 'os';
+import { join } from 'path';
+import {
+  normalizeHookInput,
+  computeGrokPlanPath,
+} from '../../../cli/hooks/stdin-parser.js';
+import { determineProjectRoot } from '../../../utils/project-root.js';
+
+describe('grok-hook-normalization', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.GROK_HOOK_EVENT;
+    delete process.env.GROK_WORKSPACE_ROOT;
+    delete process.env.GROK_SESSION_ID;
+    delete process.env.CLAUDE_PROJECT_DIR;
+    delete process.env.SQLEW_PROJECT_ROOT;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  describe('normalizeHookInput', () => {
+    it('should pass through Claude payloads unchanged', () => {
+      const input = {
+        hook_event_name: 'PostToolUse',
+        tool_name: 'ExitPlanMode',
+        cwd: 'C:/project',
+        session_id: 'abc-123',
+      };
+      const result = normalizeHookInput(input);
+      assert.strictEqual(result.hook_event_name, 'PostToolUse');
+      assert.strictEqual(result.tool_name, 'ExitPlanMode');
+      assert.strictEqual(result.client, undefined);
+    });
+
+    it('should normalize Grok camelCase payload to Claude shape', () => {
+      const result = normalizeHookInput({
+        hookEventName: 'post_tool_use',
+        toolName: 'exit_plan_mode',
+        sessionId: '019eb585-d6ec-7ae0-992a-d60340763a20',
+        workspaceRoot: 'C:\\Users\\kitayama\\RustroverProjects\\mcp-sqlew',
+      });
+      assert.strictEqual(result.client, 'grok');
+      assert.strictEqual(result.hook_event_name, 'PostToolUse');
+      assert.strictEqual(result.tool_name, 'ExitPlanMode');
+      assert.strictEqual(result.session_id, '019eb585-d6ec-7ae0-992a-d60340763a20');
+      assert.strictEqual(result.cwd, 'C:\\Users\\kitayama\\RustroverProjects\\mcp-sqlew');
+    });
+
+    it('should map enter_plan_mode PreToolUse event', () => {
+      const result = normalizeHookInput({
+        hookEventName: 'pre_tool_use',
+        toolName: 'enter_plan_mode',
+        workspaceRoot: 'C:/project',
+      });
+      assert.strictEqual(result.hook_event_name, 'PreToolUse');
+      assert.strictEqual(result.tool_name, 'EnterPlanMode');
+    });
+
+    it('should use env vars when stdin is empty', () => {
+      process.env.GROK_HOOK_EVENT = 'post_tool_use';
+      process.env.GROK_WORKSPACE_ROOT = 'C:/project';
+      process.env.GROK_SESSION_ID = 'sess-1';
+
+      const result = normalizeHookInput({});
+      assert.strictEqual(result.client, 'grok');
+      assert.strictEqual(result.hook_event_name, 'PostToolUse');
+      assert.strictEqual(result.cwd, 'C:/project');
+      assert.strictEqual(result.session_id, 'sess-1');
+    });
+  });
+
+  describe('computeGrokPlanPath', () => {
+    it('should encode Windows workspace path for session directory', () => {
+      const workspace = 'C:\\Users\\kitayama\\RustroverProjects\\mcp-sqlew';
+      const sessionId = '019eb585-d6ec-7ae0-992a-d60340763a20';
+      const planPath = computeGrokPlanPath(workspace, sessionId);
+
+      const encoded = encodeURIComponent(workspace);
+      assert.strictEqual(
+        planPath,
+        join(homedir(), '.grok', 'sessions', encoded, sessionId, 'plan.md'),
+      );
+    });
+
+    it('should reject path traversal in sessionId', () => {
+      assert.strictEqual(computeGrokPlanPath('C:/project', '../escape'), null);
+      assert.strictEqual(computeGrokPlanPath('C:/project', ''), null);
+    });
+  });
+
+  describe('determineProjectRoot', () => {
+    it('should prefer GROK_WORKSPACE_ROOT over SQLEW_PROJECT_ROOT', () => {
+      process.env.GROK_WORKSPACE_ROOT = 'C:/grok-workspace';
+      process.env.SQLEW_PROJECT_ROOT = 'C:/other';
+      assert.strictEqual(determineProjectRoot({}), 'C:/grok-workspace');
+    });
+
+    it('should prefer CLAUDE_PROJECT_DIR over GROK_WORKSPACE_ROOT', () => {
+      process.env.CLAUDE_PROJECT_DIR = 'C:/claude-project';
+      process.env.GROK_WORKSPACE_ROOT = 'C:/grok-workspace';
+      assert.strictEqual(determineProjectRoot({}), 'C:/claude-project');
+    });
+  });
+});

--- a/src/tests/unit/hooks/grok-plan-template-injection.test.ts
+++ b/src/tests/unit/hooks/grok-plan-template-injection.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Grok Build plan.md template injection unit tests
+ *
+ * @since v5.2.0
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  injectGrokPlanTemplate,
+  PLAN_TEMPLATE_MARKER,
+} from '../../../cli/hooks/track-plan.js';
+
+describe('injectGrokPlanTemplate', () => {
+  let testDir: string;
+  let planPath: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `sqlew-grok-plan-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(testDir, { recursive: true });
+    planPath = join(testDir, 'plan.md');
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should create plan.md with template when file does not exist', () => {
+    const injected = injectGrokPlanTemplate(planPath);
+    assert.strictEqual(injected, true);
+    assert.ok(existsSync(planPath));
+    const content = readFileSync(planPath, 'utf-8');
+    assert.ok(content.includes(PLAN_TEMPLATE_MARKER));
+    assert.ok(content.includes('### 📌 Decision:'));
+    assert.ok(content.includes('### 🚫 Constraint:'));
+  });
+
+  it('should append template when plan exists without marker or patterns', () => {
+    writeFileSync(planPath, '# My Plan\n\nSome content.\n', 'utf-8');
+    const injected = injectGrokPlanTemplate(planPath);
+    assert.strictEqual(injected, true);
+    const content = readFileSync(planPath, 'utf-8');
+    assert.ok(content.startsWith('# My Plan'));
+    assert.ok(content.includes(PLAN_TEMPLATE_MARKER));
+  });
+
+  it('should skip when template marker already present', () => {
+    writeFileSync(planPath, `# Plan\n\n${PLAN_TEMPLATE_MARKER}\n`, 'utf-8');
+    const injected = injectGrokPlanTemplate(planPath);
+    assert.strictEqual(injected, false);
+    const content = readFileSync(planPath, 'utf-8');
+    assert.strictEqual((content.match(new RegExp(PLAN_TEMPLATE_MARKER, 'g')) || []).length, 1);
+  });
+
+  it('should skip when real decision patterns already exist', () => {
+    writeFileSync(
+      planPath,
+      '### 📌 Decision: auth/strategy\n- **Value**: Use JWT\n- **Layer**: business\n',
+      'utf-8',
+    );
+    const injected = injectGrokPlanTemplate(planPath);
+    assert.strictEqual(injected, false);
+  });
+});

--- a/src/utils/project-root.ts
+++ b/src/utils/project-root.ts
@@ -2,7 +2,8 @@
  * Project Root Determination Utility
  *
  * Determines the project root directory with correct priority order:
- * 0. CLAUDE_PROJECT_DIR environment variable (Claude Code Hooks set this automatically)
+ * 0. CLAUDE_PROJECT_DIR environment variable (Claude Code / Grok Build hooks)
+ * 0b. GROK_WORKSPACE_ROOT environment variable (Grok Build hooks / MCP)
  * 1. SQLEW_PROJECT_ROOT environment variable (MCP client can set this)
  * 2. CLI --db-path argument (absolute path) → use dirname
  * 3. CLI --config-path argument (absolute path) → use dirname
@@ -13,7 +14,8 @@
  * like C:\Windows\System32 (e.g., by MCP hosts like Claude Desktop or Junie AI).
  *
  * Environment Variable Support:
- * - CLAUDE_PROJECT_DIR: Set automatically by Claude Code Hooks (v4.1.0+)
+ * - CLAUDE_PROJECT_DIR: Set automatically by Claude Code / Grok Build hooks (v4.1.0+)
+ * - GROK_WORKSPACE_ROOT: Set automatically by Grok Build hooks (v5.2.0+)
  * - SQLEW_PROJECT_ROOT: MCP clients can set this (Serena-MCP pattern)
  * This allows project-relative database paths without absolute CLI arguments.
  */
@@ -44,7 +46,8 @@ export interface ProjectRootOptions {
  * Determines the project root directory based on available path information.
  *
  * Priority order (highest to lowest):
- * 0. CLAUDE_PROJECT_DIR environment variable (Claude Code Hooks)
+ * 0. CLAUDE_PROJECT_DIR environment variable (Claude Code / Grok Build hooks)
+ * 0b. GROK_WORKSPACE_ROOT environment variable (Grok Build)
  * 1. SQLEW_PROJECT_ROOT environment variable
  * 2. CLI --db-path (absolute)
  * 3. CLI --config-path (absolute)
@@ -85,6 +88,12 @@ export function determineProjectRoot(options: ProjectRootOptions = {}): string {
   if (claudeProjectDir && path.isAbsolute(claudeProjectDir)) {
     // Normalize to forward slashes for cross-platform consistency
     return claudeProjectDir.replace(/\\/g, '/');
+  }
+
+  // Priority 0b: GROK_WORKSPACE_ROOT (Grok Build hooks inject this on every hook process)
+  const grokWorkspaceRoot = process.env.GROK_WORKSPACE_ROOT;
+  if (grokWorkspaceRoot && path.isAbsolute(grokWorkspaceRoot)) {
+    return grokWorkspaceRoot.replace(/\\/g, '/');
   }
 
   // Priority 1: SQLEW_PROJECT_ROOT environment variable


### PR DESCRIPTION
## Summary

- Add Grok Build support in sqlew v5.2.0 (hook normalization, plan.md template injection, MCP project root fix)
- Release documentation: CHANGELOG, README, HOOKS_GUIDE with `grok plugin install sqlew-io/sqlew-plugin --trust`
- Bump npm/manifest versioning to 5.2.0

## Decision: Grok plan template via file injection (skills auto-invocation is unreliable)

Grok ignores passive hook stdout. Decision/Constraint template is appended to `plan.md` on `enter_plan_mode` as a file side-effect.

- `src/cli/hooks/track-plan.ts`: `injectGrokPlanTemplate()` on Grok EnterPlanMode
- `src/tests/unit/hooks/grok-plan-template-injection.test.ts`: injection unit tests

## Decision: Unified hook normalization for Claude Code and Grok Build

Single sqlew-plugin drives Plan-to-ADR on both platforms via canonical HookInput translation.

- `src/cli/hooks/stdin-parser.ts`: `normalizeHookInput()`, `computeGrokPlanPath()`, Grok `sendBlock()` deny JSON
- `src/cli/hooks/on-exit-plan.ts`, `plan-processor.ts`: Grok `plan_path` resolution and debug logging
- `src/cli/hooks/on-prompt.ts`: Grok no-op (UserPromptSubmit stdout ignored)
- `src/utils/project-root.ts`: `GROK_WORKSPACE_ROOT` support for MCP startup
- `src/config/global-config.ts`: `plan_path` field in session cache
- `src/tests/unit/hooks/grok-hook-normalization.test.ts`: normalization tests

## Constraint: Plugin-only hook registration for Grok

Do not duplicate sqlew hooks in `~/.grok/hooks/` or global `config.toml` MCP entry.

- `docs/HOOKS_GUIDE.md`: GitHub plugin install, anti-duplication notes

## Other Changes

- `CHANGELOG.md`, `README.md`, `manifest.json`, `package-lock.json`: v5.2.0 release notes and install instructions
- `.gitignore`: ignore `mcps/`, `.indexion/` (local tooling artifacts)