### PR TITLE
fix: detect Grok plan-mode tool names in isPlanMode (v5.2.1)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
+# Normalize text files to LF (cross-platform + jj compatibility on Windows)
+* text=auto eol=lf
+
 # Shell scripts must use LF line endings
 *.sh text eol=lf
 .husky/* text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Jujutsu (colocated with git; local metadata only)
+.jj/
+
 # Claude Code configuration (keep these)
 .claude
 .mcp.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [5.2.1] - 2026-06-12
+
+### Fixed
+
+**`isPlanMode()` — Grok plan-mode tool names not detected after normalization**
+
+`normalizeHookInput()` maps Grok's `enter_plan_mode` / `exit_plan_mode` tool names to the canonical Claude-shaped `EnterPlanMode` / `ExitPlanMode` before any detection runs. `isPlanMode()` only checked the raw snake_case names, so the tool-name branch never matched and Grok Build's plan mode was never detected via tool context.
+
+- **`isPlanMode()`** — Now matches the normalized `EnterPlanMode` / `ExitPlanMode` names. Raw snake_case names are still accepted defensively for callers that bypass normalization.
+- **Tests** — Added `isPlanMode` regression coverage to `grok-hook-normalization.test.ts` (Claude `permission_mode`, normalized Grok payloads, raw snake_case, non-plan tools).
+
+Claude Code was unaffected by this bug because it is detected via `permission_mode === 'plan'`, which is evaluated first.
+
+> **Note:** Plan-mode ADR enforcement requires the sqlew plugin to be enabled in the active scope. Enabling it only per-project (`.claude/settings.local.json`) silently skips enforcement in other projects; enable `sqlew@sqlew-plugin` in the global `~/.claude/settings.json` for always-on coverage.
+
+---
+
 ## [5.2.0] - 2026-06-11
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "sqlew",
   "display_name": "sqlew - Context Manager for AI Agents",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Token-efficient context management for AI coding agents. Record architectural decisions, constraints, and maintain project knowledge across sessions. Supports SQLite local storage and sqlew.io cloud backend.",
   "author": {
     "name": "sqlew.io",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlew",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlew",
-      "version": "5.2.0",
+      "version": "5.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.21.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sqlew",
   "description": "Automated ADR (Architecture Decision Records) for AI Coding Agents - MCP server with SQL-backed decision repository",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "main": "dist/index.js",
   "type": "module",
   "bin": {

--- a/src/cli/hooks/stdin-parser.ts
+++ b/src/cli/hooks/stdin-parser.ts
@@ -403,11 +403,17 @@ export function isPlanMode(input: HookInput): boolean {
   if (input.permission_mode === 'plan') return true;
 
   // Grok Build: plan mode is signaled via the enter_plan_mode / exit_plan_mode tools
-  // (no permission_mode field). The actual "active" state is best detected by the
-  // presence of a tracked plan for the project + tool context, but for simple
-  // enforcement we also accept explicit tool names in the current hook payload.
+  // (no permission_mode field). normalizeHookInput() maps these to the Claude-shaped
+  // EnterPlanMode / ExitPlanMode before any detection runs, so match the normalized
+  // names. Raw snake_case names are also accepted defensively for callers that
+  // bypass normalization.
   const tool = input.tool_name;
-  if (tool === 'enter_plan_mode' || tool === 'exit_plan_mode') {
+  if (
+    tool === 'EnterPlanMode' ||
+    tool === 'ExitPlanMode' ||
+    tool === 'enter_plan_mode' ||
+    tool === 'exit_plan_mode'
+  ) {
     return true;
   }
 

--- a/src/tests/unit/hooks/grok-hook-normalization.test.ts
+++ b/src/tests/unit/hooks/grok-hook-normalization.test.ts
@@ -13,6 +13,7 @@ import { join } from 'path';
 import {
   normalizeHookInput,
   computeGrokPlanPath,
+  isPlanMode,
 } from '../../../cli/hooks/stdin-parser.js';
 import { determineProjectRoot } from '../../../utils/project-root.js';
 
@@ -79,6 +80,50 @@ describe('grok-hook-normalization', () => {
       assert.strictEqual(result.hook_event_name, 'PostToolUse');
       assert.strictEqual(result.cwd, 'C:/project');
       assert.strictEqual(result.session_id, 'sess-1');
+    });
+  });
+
+  describe('isPlanMode', () => {
+    it('should detect Claude plan mode via permission_mode', () => {
+      assert.strictEqual(
+        isPlanMode({ hook_event_name: 'UserPromptSubmit', permission_mode: 'plan' }),
+        true,
+      );
+    });
+
+    it('should return false for Claude non-plan prompts', () => {
+      assert.strictEqual(
+        isPlanMode({ hook_event_name: 'UserPromptSubmit', permission_mode: 'default' }),
+        false,
+      );
+    });
+
+    it('should detect Grok plan mode after normalization (enter_plan_mode)', () => {
+      // Regression: normalizeHookInput maps enter_plan_mode -> EnterPlanMode,
+      // so isPlanMode must match the normalized PascalCase name.
+      const normalized = normalizeHookInput({
+        hookEventName: 'pre_tool_use',
+        toolName: 'enter_plan_mode',
+        workspaceRoot: 'C:/project',
+      });
+      assert.strictEqual(isPlanMode(normalized), true);
+    });
+
+    it('should detect Grok plan mode after normalization (exit_plan_mode)', () => {
+      const normalized = normalizeHookInput({
+        hookEventName: 'post_tool_use',
+        toolName: 'exit_plan_mode',
+        workspaceRoot: 'C:/project',
+      });
+      assert.strictEqual(isPlanMode(normalized), true);
+    });
+
+    it('should accept raw snake_case tool names defensively', () => {
+      assert.strictEqual(isPlanMode({ tool_name: 'enter_plan_mode' }), true);
+    });
+
+    it('should return false for unrelated tools', () => {
+      assert.strictEqual(isPlanMode({ tool_name: 'Bash' }), false);
     });
   });
 

--- a/src/tests/unit/hooks/grok-hook-normalization.test.ts
+++ b/src/tests/unit/hooks/grok-hook-normalization.test.ts
@@ -147,16 +147,23 @@ describe('grok-hook-normalization', () => {
   });
 
   describe('determineProjectRoot', () => {
+    // determineProjectRoot uses path.isAbsolute(), which is platform-specific:
+    // 'C:/...' is absolute only on win32. Build paths that are absolute on the
+    // current platform so the precedence assertions hold on Linux CI too.
+    const absRoot = (p: string): string => (process.platform === 'win32' ? `C:${p}` : p);
+
     it('should prefer GROK_WORKSPACE_ROOT over SQLEW_PROJECT_ROOT', () => {
-      process.env.GROK_WORKSPACE_ROOT = 'C:/grok-workspace';
-      process.env.SQLEW_PROJECT_ROOT = 'C:/other';
-      assert.strictEqual(determineProjectRoot({}), 'C:/grok-workspace');
+      const grokRoot = absRoot('/grok-workspace');
+      process.env.GROK_WORKSPACE_ROOT = grokRoot;
+      process.env.SQLEW_PROJECT_ROOT = absRoot('/other');
+      assert.strictEqual(determineProjectRoot({}), grokRoot);
     });
 
     it('should prefer CLAUDE_PROJECT_DIR over GROK_WORKSPACE_ROOT', () => {
-      process.env.CLAUDE_PROJECT_DIR = 'C:/claude-project';
-      process.env.GROK_WORKSPACE_ROOT = 'C:/grok-workspace';
-      assert.strictEqual(determineProjectRoot({}), 'C:/claude-project');
+      const claudeRoot = absRoot('/claude-project');
+      process.env.CLAUDE_PROJECT_DIR = claudeRoot;
+      process.env.GROK_WORKSPACE_ROOT = absRoot('/grok-workspace');
+      assert.strictEqual(determineProjectRoot({}), claudeRoot);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes plan-mode detection for Grok Build, where `isPlanMode()` failed to recognize the `enter_plan_mode` / `exit_plan_mode` tools after hook input normalization. Patch release **5.2.1**.

## Problem

`normalizeHookInput()` maps Grok's snake_case tool names to the canonical Claude-shaped names (`enter_plan_mode` -> `EnterPlanMode`, `exit_plan_mode` -> `ExitPlanMode`) before any detection runs. But `isPlanMode()` only checked the raw snake_case names, so the tool-name branch never matched on normalized input and Grok Build's plan mode was never detected via tool context.

Claude Code was unaffected, since it is detected earlier via `permission_mode === 'plan'`.

## Architecture Decisions

### Decision: hooks/grok-plan-mode-tool-names
- **Value**: `isPlanMode()` tool-name detection runs against the normalized names (`EnterPlanMode` / `ExitPlanMode`); raw snake_case names are still accepted defensively.
- **Layer**: infrastructure
- **Rationale**: Detection always runs after `normalizeHookInput()`, which rewrites `enter_plan_mode` -> `EnterPlanMode`. Checking only the snake_case form made the branch dead code.
- **Files**: `src/cli/hooks/stdin-parser.ts`

### Constraint: architecture
- **Rule**: Hook input field comparisons (e.g. `tool_name`) must assume `normalizeHookInput()`-normalized values. Do not branch on raw client-specific values (Grok snake_case, etc.) inside detection logic.
- **Priority**: high
- **Tags**: hooks, stdin-parser, grok, normalization

## Other Changes

- **Tests** (`src/tests/unit/hooks/grok-hook-normalization.test.ts`): Added `isPlanMode` regression coverage - Claude `permission_mode`, normalized Grok payloads (enter/exit), raw snake_case, and non-plan tools.
- **Version bump** 5.2.0 -> 5.2.1: `package.json`, `package-lock.json`, `manifest.json`.
- **CHANGELOG.md**: Added the `[5.2.1]` section, including an operational note that the sqlew plugin must be enabled in the global `~/.claude/settings.json` (not only per-project) for always-on plan-mode ADR enforcement.
- **.gitattributes / .gitignore**: Minor housekeeping included in the same commit.

## Test plan

- `npx tsc` passes
- Unit suite 309/309 (6 new `isPlanMode` cases); feature suite 104/104
- Manual: `sqlew on-prompt` with `permission_mode=plan` injects enforcement; non-plan input outputs nothing.