### PR TITLE
feat(codex): Codex hook support v5.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [5.2.1] - 2026-06-12
 
+### Added
+
+**Codex hook support (paired with sqlew-plugin v5.2.1)**
+
+MCP hook layer for OpenAI Codex, following the same normalization pattern as Grok Build (v5.2.0). Plugin manifests and hook matchers ship in [sqlew-plugin](https://github.com/sqlew-io/sqlew-plugin) v5.2.1.
+
+- **`normalizeHookInput()` Codex branch** — Maps `shell_command`/`shell`/`exec_command` → `Bash`, `apply_patch` → `Edit`, reads `collaboration_mode` for Plan mode
+- **`codex-transcript.ts`** — Locates `~/.codex/sessions/**/{sessionId}.jsonl` and extracts Plan-mode assistant text for ADR pattern processing
+- **`on-prompt` / `on-exit-plan` Codex paths** — Plan enforcement injection and transcript-based extraction on session `Stop`
+- **`determineProjectRoot()`** — `CODEX_CWD` environment variable support
+- **Unit tests** — `codex-hook-normalization.test.ts`
+- **Docs** — `README.md` and `HOOKS_GUIDE.md` updated; manual `sqlew-codex-skills` copy install deprecated
+
 ### Fixed
 
 **`isPlanMode()` — Grok plan-mode tool names not detected after normalization**

--- a/README.md
+++ b/README.md
@@ -54,9 +54,14 @@ claude plugin install sqlew
 
 The plugin automatically configures MCP server, Skills (Plan Mode guidance), and Hooks (automatic decision capture).
 
-#### Codex CLI
+#### Codex CLI (Plugin)
 
-See [sqlew-codex](https://github.com/sqlew-io/sqlew-codex) for Codex CLI integration.
+```bash
+codex plugin marketplace add sqlew-io/sqlew-plugin
+codex plugin install sqlew --source sqlew-plugin
+```
+
+After install, open `/hooks` in Codex and trust the bundled sqlew hooks. Enable Plan Mode with `collaboration_modes = true` under `[features]` in your Codex config. The plugin configures MCP server, Skills (plan mode guidance), and Hooks (plan enforcement, PR ADR guard, decision extraction). See [Hooks Guide](docs/HOOKS_GUIDE.md) for caveats (do not duplicate skills in `~/.codex/skills/` or add `[mcp_servers.sqlew]` to `config.toml`).
 
 #### Grok Build (Plugin)
 
@@ -96,7 +101,7 @@ No special commands needed — just plan your work normally, and sqlew captures 
 - **Fast Queries** — 2-50ms retrieval via SQL, even with thousands of decisions
 - **Duplicate Detection** — Three-tier similarity scoring (0-100) prevents redundant decisions
 - **Constraint Tracking** — Architectural rules and principles as first-class entities
-- **Auto-Capture** — Hooks automatically record decisions from Plan Mode (Claude Code and Grok Build via sqlew-plugin)
+- **Auto-Capture** — Hooks automatically record decisions from Plan Mode (Claude Code, Codex, and Grok Build via sqlew-plugin)
 - **Multi-Database** — SQLite (default), PostgreSQL, MySQL/MariaDB, or Cloud
 - **Git Worktree Ready** — Each worktree shares the same context database
 

--- a/docs/HOOKS_GUIDE.md
+++ b/docs/HOOKS_GUIDE.md
@@ -35,21 +35,34 @@ Source: https://github.com/sqlew-io/sqlew-plugin
 ## Codex
 
 ```bash
-git clone https://github.com/sqlew-io/sqlew-codex.git
-cp -r sqlew-codex/copy_to_codex_dir/* ~/.codex/
+npm i -g sqlew
+codex plugin marketplace add sqlew-io/sqlew-plugin
+codex plugin install sqlew --source sqlew-plugin
 ```
 
-Then add to `~/.codex/config.toml`:
+After install, trust bundled hooks via `/hooks` in Codex.
+
+Enable Plan mode when needed:
 
 ```toml
-[mcp_servers.sqlew]
-command = "sqlew"
-args = []
+[features]
+collaboration_modes = true
 ```
 
-To uninstall, remove the copied skill directories and config entries.
+The plugin automatically configures:
+- MCP server settings (`.mcp.json`)
+- Skills (plan mode guidance, decision format, PR ADR)
+- Hooks (plan enforcement, PR ADR guard, decision extraction)
 
-Source: https://github.com/sqlew-io/sqlew-codex
+To uninstall:
+
+```bash
+codex plugin remove sqlew
+```
+
+**Legacy manual install** (deprecated): see [sqlew-codex-skills](https://github.com/sqlew-io/sqlew-codex-skills).
+
+Source: https://github.com/sqlew-io/sqlew-plugin
 
 ## Grok Build
 
@@ -88,14 +101,16 @@ Source: https://github.com/sqlew-io/sqlew-plugin
 
 | Feature | Claude Code | Codex | Grok Build |
 |---------|-------------|-------|------------|
-| MCP server | Auto-configured | Manual (config.toml) | Plugin `.mcp.json` |
-| Plan-to-ADR | Skills + Hooks | Skills + System prompt | Skills + Hooks |
-| PR enrichment | Skill (sqlew-pr-adr) | Skill (sqlew-pr-adr) | Skill (sqlew-pr-adr) |
+| Install | `claude plugin install` | `codex plugin install` | `grok plugin install` |
+| MCP server | Plugin `.mcp.json` | Plugin `.mcp.json` | Plugin `.mcp.json` |
+| Plan-to-ADR | Skills + Hooks | Skills + Hooks | Skills + Hooks |
+| PR enrichment | Skill + Hook | Skill + Hook | Skill + Hook |
 | Decision format guidance | Skill (sqlew-decision-format) | Skill (sqlew-decision-format) | Skill (sqlew-decision-format) |
 
 ## Version History
 
+- **v5.2.1**: Codex plugin support via sqlew-plugin (`.codex-plugin`, marketplace, hook normalization, transcript-based plan extraction)
 - **v5.2.0**: Grok Build support via sqlew-plugin (hook normalization, Grok plan path, skills-based plan guidance)
-- **v5.0.0**: Plugin-first architecture (sqlew-plugin for Claude Code, sqlew-codex for Codex)
+- **v5.0.0**: Plugin-first architecture (sqlew-plugin for Claude Code; manual sqlew-codex-skills for Codex — now deprecated)
 - **v4.3.0**: Plan-to-ADR - Automatic ADR from Plan Mode
 - **v4.1.0**: Initial Claude Code Hooks integration

--- a/src/cli/hooks/codex-transcript.ts
+++ b/src/cli/hooks/codex-transcript.ts
@@ -1,0 +1,152 @@
+/**
+ * Codex transcript helpers for Plan-to-ADR extraction.
+ *
+ * Codex stores session rollouts as JSONL under ~/.codex/sessions/ rather than
+ * a dedicated plan.md file. These helpers locate the transcript and extract
+ * assistant plan text written during collaboration Plan mode.
+ *
+ * @since v5.2.1
+ */
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+
+const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+/**
+ * Recursively search ~/.codex/sessions for a rollout JSONL ending with sessionId.
+ */
+export function findCodexTranscriptPath(sessionId: string): string | null {
+  if (!sessionId || !SESSION_ID_PATTERN.test(sessionId)) {
+    return null;
+  }
+
+  const suffix = `${sessionId}.jsonl`;
+  const root = join(homedir(), '.codex', 'sessions');
+  if (!existsSync(root)) {
+    return null;
+  }
+
+  return searchJsonlBySuffix(root, suffix);
+}
+
+function searchJsonlBySuffix(dir: string, suffix: string): string | null {
+  for (const entry of readdirSync(dir)) {
+    const fullPath = join(dir, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory()) {
+      const found = searchJsonlBySuffix(fullPath, suffix);
+      if (found) {
+        return found;
+      }
+      continue;
+    }
+    if (entry.endsWith(suffix)) {
+      return fullPath;
+    }
+  }
+  return null;
+}
+
+function isPlanCollaborationMode(mode: unknown): boolean {
+  if (typeof mode === 'string') {
+    return mode.toLowerCase() === 'plan';
+  }
+  if (mode && typeof mode === 'object') {
+    const record = mode as Record<string, unknown>;
+    if (typeof record.mode === 'string') {
+      return record.mode.toLowerCase() === 'plan';
+    }
+    if (typeof record.kind === 'string') {
+      return record.kind.toLowerCase() === 'plan';
+    }
+  }
+  return false;
+}
+
+/**
+ * Extract assistant plan text from a Codex rollout JSONL transcript.
+ * Returns concatenated assistant output from turns that ran in Plan mode.
+ */
+export function extractPlanMarkdownFromCodexTranscript(transcriptPath: string): string | null {
+  if (!existsSync(transcriptPath)) {
+    return null;
+  }
+
+  const lines = readFileSync(transcriptPath, 'utf-8').split('\n').filter((line) => line.trim());
+  const chunks: string[] = [];
+  let inPlanMode = false;
+
+  for (const line of lines) {
+    let entry: Record<string, unknown>;
+    try {
+      entry = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+
+    const type = entry.type;
+    const payload = entry.payload as Record<string, unknown> | undefined;
+    if (!payload) {
+      continue;
+    }
+
+    if (type === 'turn_context') {
+      inPlanMode = isPlanCollaborationMode(payload.collaboration_mode);
+      continue;
+    }
+
+    if (type === 'event_msg') {
+      if (isPlanCollaborationMode(payload.collaboration_mode_kind)) {
+        inPlanMode = true;
+      }
+      if (payload.type === 'task_complete' || payload.type === 'turn_complete') {
+        // Keep plan mode sticky until an explicit default-mode turn_context arrives.
+      }
+      continue;
+    }
+
+    if (!inPlanMode || type !== 'response_item') {
+      continue;
+    }
+
+    const item = payload;
+    if (item.type !== 'message' || item.role !== 'assistant') {
+      continue;
+    }
+
+    const content = item.content;
+    if (!Array.isArray(content)) {
+      continue;
+    }
+
+    for (const part of content) {
+      if (!part || typeof part !== 'object') {
+        continue;
+      }
+      const block = part as Record<string, unknown>;
+      if (block.type === 'output_text' && typeof block.text === 'string' && block.text.trim()) {
+        chunks.push(block.text.trim());
+      }
+    }
+  }
+
+  if (chunks.length === 0) {
+    return null;
+  }
+
+  return chunks.join('\n\n');
+}
+
+/**
+ * Write extracted Codex plan text to a project-local temp markdown file.
+ */
+export function materializeCodexPlanFile(projectPath: string, sessionId: string, content: string): string {
+  const dir = join(projectPath, '.sqlew', 'tmp');
+  mkdirSync(dir, { recursive: true });
+  const safeId = sessionId.replace(/[^A-Za-z0-9_-]/g, '').slice(0, 32) || 'codex';
+  const planPath = join(dir, `codex-plan-${safeId}.md`);
+  writeFileSync(planPath, content, 'utf-8');
+  return planPath;
+}

--- a/src/cli/hooks/on-exit-plan.ts
+++ b/src/cli/hooks/on-exit-plan.ts
@@ -15,6 +15,11 @@ import { randomUUID } from 'crypto';
 import { readStdinJson, sendContinue, sendPostToolUseContext, getProjectPath, computeGrokPlanPath } from './stdin-parser.js';
 import { loadCurrentPlan, saveCurrentPlan, type CurrentPlanInfo } from '../../config/global-config.js';
 import { processPlanPatterns } from './plan-processor.js';
+import {
+  extractPlanMarkdownFromCodexTranscript,
+  findCodexTranscriptPath,
+  materializeCodexPlanFile,
+} from './codex-transcript.js';
 import { debugLog } from '../../utils/debug-logger.js';
 
 // ============================================================================
@@ -31,13 +36,18 @@ export async function onExitPlanCommand(): Promise<void> {
   try {
     const input = await readStdinJson();
 
-    // Only process ExitPlanMode
-    if (input.tool_name !== 'ExitPlanMode') {
+    const projectPath = getProjectPath(input);
+    const isExitPlanTool = input.tool_name === 'ExitPlanMode';
+    const isCodexStopWithPendingPlan =
+      input.client === 'codex' &&
+      input.hook_event_name === 'Stop' &&
+      !!projectPath &&
+      !!loadCurrentPlan(projectPath)?.decision_pending;
+
+    if (!isExitPlanTool && !isCodexStopWithPendingPlan) {
       sendContinue();
       return;
     }
-
-    const projectPath = getProjectPath(input);
     if (!projectPath) {
       debugLog('WARN', '[on-exit-plan] No project path', {
         client: input.client,
@@ -75,6 +85,35 @@ export async function onExitPlanCommand(): Promise<void> {
           enforcement_shown_at: sameSession ? existing?.enforcement_shown_at : undefined,
         };
         saveCurrentPlan(projectPath, planInfo);
+      }
+    }
+
+    if (input.client === 'codex') {
+      const existing = loadCurrentPlan(projectPath);
+      const transcriptPath =
+        input.transcript_path ||
+        existing?.plan_path ||
+        (input.session_id ? findCodexTranscriptPath(input.session_id) : null);
+
+      if (transcriptPath) {
+        const extracted = extractPlanMarkdownFromCodexTranscript(transcriptPath);
+        if (extracted) {
+          const materializedPath = materializeCodexPlanFile(
+            projectPath,
+            input.session_id || existing?.plan_id || 'codex',
+            extracted,
+          );
+          const planInfo: CurrentPlanInfo = {
+            plan_id: existing?.plan_id || randomUUID(),
+            plan_file: 'codex-plan.md',
+            plan_path: materializedPath,
+            plan_updated_at: new Date().toISOString(),
+            recorded: existing?.recorded ?? false,
+            decision_pending: existing?.decision_pending ?? true,
+            enforcement_shown_at: existing?.enforcement_shown_at,
+          };
+          saveCurrentPlan(projectPath, planInfo);
+        }
       }
     }
 

--- a/src/cli/hooks/on-prompt.ts
+++ b/src/cli/hooks/on-prompt.ts
@@ -19,8 +19,10 @@
  * @modified v5.0.7 - First/repeat message split, inline template, isPlanMode()
  */
 
+import { randomUUID } from 'crypto';
 import { readStdinJson, isPlanMode, getProjectPath } from './stdin-parser.js';
-import { loadCurrentPlan, saveCurrentPlan } from '../../config/global-config.js';
+import { loadCurrentPlan, saveCurrentPlan, type CurrentPlanInfo } from '../../config/global-config.js';
+import { findCodexTranscriptPath } from './codex-transcript.js';
 
 // ============================================================================
 // Plan Mode Enforcement Context
@@ -98,7 +100,24 @@ export async function onPromptCommand(): Promise<void> {
       return;
     }
 
-    const planInfo = loadCurrentPlan(projectPath);
+    let planInfo = loadCurrentPlan(projectPath);
+
+    if (input.client === 'codex' && !planInfo) {
+      const transcriptPath =
+        input.transcript_path ||
+        (input.session_id ? findCodexTranscriptPath(input.session_id) : undefined) ||
+        undefined;
+      const codexPlanInfo: CurrentPlanInfo = {
+        plan_id: randomUUID(),
+        plan_file: 'codex-plan.md',
+        plan_path: transcriptPath,
+        plan_updated_at: new Date().toISOString(),
+        recorded: false,
+        decision_pending: true,
+      };
+      saveCurrentPlan(projectPath, codexPlanInfo);
+      planInfo = codexPlanInfo;
+    }
 
     if (!planInfo || !planInfo.enforcement_shown_at) {
       // First prompt in this plan session → full message with inline template

--- a/src/cli/hooks/stdin-parser.ts
+++ b/src/cli/hooks/stdin-parser.ts
@@ -90,8 +90,10 @@ export interface HookInput {
   source?: 'startup' | 'resume' | 'clear' | 'compact';
   /** SessionEnd reason: clear | logout | prompt_input_exit | other */
   reason?: 'clear' | 'logout' | 'prompt_input_exit' | 'other';
-  /** Originating client, set by normalizeHookInput() (e.g., 'grok'). undefined = Claude/native. */
-  client?: 'grok' | 'claude';
+  /** Codex collaboration mode (e.g. plan, default). */
+  collaboration_mode?: string;
+  /** Originating client, set by normalizeHookInput() (e.g., 'grok', 'codex'). undefined = Claude/native. */
+  client?: 'grok' | 'codex' | 'claude';
 }
 
 /**
@@ -172,6 +174,69 @@ const GROK_TOOL_MAP: Record<string, string> = {
   read_file: 'Read',
 };
 
+/** Codex CLI tool names mapped to Claude-shaped names used by sqlew hook handlers. */
+const CODEX_TOOL_MAP: Record<string, string> = {
+  shell_command: 'Bash',
+  shell: 'Bash',
+  exec_command: 'Bash',
+  apply_patch: 'Edit',
+  enter_plan_mode: 'EnterPlanMode',
+  exit_plan_mode: 'ExitPlanMode',
+};
+
+const CODEX_NATIVE_TOOLS = new Set(Object.keys(CODEX_TOOL_MAP));
+
+function extractCollaborationMode(raw: Record<string, unknown>): string | undefined {
+  const direct = raw.collaboration_mode ?? raw.collaborationMode;
+  if (typeof direct === 'string') {
+    return direct;
+  }
+  if (direct && typeof direct === 'object') {
+    const record = direct as Record<string, unknown>;
+    if (typeof record.mode === 'string') {
+      return record.mode;
+    }
+    if (typeof record.kind === 'string') {
+      return record.kind;
+    }
+  }
+  const kind = raw.collaboration_mode_kind ?? raw.collaborationModeKind;
+  return typeof kind === 'string' ? kind : undefined;
+}
+
+function isCodexPayload(raw: Record<string, unknown>): boolean {
+  const tool = (raw.tool_name || raw.toolName) as string | undefined;
+  if (tool && CODEX_NATIVE_TOOLS.has(tool)) {
+    return true;
+  }
+  if (extractCollaborationMode(raw)) {
+    return true;
+  }
+  if (process.env.CODEX_SESSION_ID || process.env.CODEX_CWD || process.env.CODEX_HOME) {
+    return true;
+  }
+  return false;
+}
+
+function normalizeCodexPayload(raw: Record<string, unknown>): HookInput {
+  const rawTool = (raw.tool_name || raw.toolName) as string | undefined;
+  const collaborationMode = extractCollaborationMode(raw);
+
+  return {
+    ...(raw as HookInput),
+    client: 'codex',
+    tool_name: rawTool ? CODEX_TOOL_MAP[rawTool] || rawTool : (raw.tool_name as string | undefined),
+    tool_input: (raw.tool_input || raw.toolInput) as ToolInput | undefined,
+    session_id: (raw.session_id || raw.sessionId || process.env.CODEX_SESSION_ID) as string | undefined,
+    cwd: (raw.cwd || process.env.CODEX_CWD || process.env.CLAUDE_PROJECT_DIR) as string | undefined,
+    transcript_path: (raw.transcript_path || raw.transcriptPath) as string | undefined,
+    collaboration_mode: collaborationMode,
+    permission_mode:
+      (raw.permission_mode as string | undefined) ||
+      (collaborationMode?.toLowerCase() === 'plan' ? 'plan' : (raw.permission_mode as string | undefined)),
+  };
+}
+
 /**
  * Normalize a raw hook payload into the canonical (Claude-shaped) HookInput.
  *
@@ -200,8 +265,12 @@ export function normalizeHookInput(raw: unknown): HookInput {
     process.env.GROK_WORKSPACE_ROOT
   );
 
-  // Claude / native: pass through unchanged
-  if (!isGrok) {
+  if (isGrok) {
+    // Grok branch below
+  } else if (isCodexPayload(r)) {
+    return normalizeCodexPayload(r);
+  } else {
+    // Claude / native: pass through unchanged
     return r as HookInput;
   }
 
@@ -399,8 +468,9 @@ export function sendUpdatedInput(originalInput: ToolInput, modifications: Partia
  * @returns true if the current session is in plan mode
  */
 export function isPlanMode(input: HookInput): boolean {
-  // Claude Code
+  // Claude Code / Codex collaboration Plan mode
   if (input.permission_mode === 'plan') return true;
+  if (input.collaboration_mode?.toLowerCase() === 'plan') return true;
 
   // Grok Build: plan mode is signaled via the enter_plan_mode / exit_plan_mode tools
   // (no permission_mode field). normalizeHookInput() maps these to the Claude-shaped
@@ -417,7 +487,6 @@ export function isPlanMode(input: HookInput): boolean {
     return true;
   }
 
-  // Future: Codex, Cursor, etc.
   return false;
 }
 
@@ -473,7 +542,12 @@ export function areAllTodosCompleted(input: HookInput): boolean {
  * @returns Project path or undefined
  */
 export function getProjectPath(input: HookInput): string | undefined {
-  return input.cwd || process.env.CLAUDE_PROJECT_DIR || process.env.GROK_WORKSPACE_ROOT;
+  return (
+    input.cwd ||
+    process.env.CLAUDE_PROJECT_DIR ||
+    process.env.CODEX_CWD ||
+    process.env.GROK_WORKSPACE_ROOT
+  );
 }
 
 /**

--- a/src/tests/unit/hooks/codex-hook-normalization.test.ts
+++ b/src/tests/unit/hooks/codex-hook-normalization.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Codex Hook Normalization Unit Tests
+ *
+ * @since v5.2.1
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { homedir } from 'os';
+import { join } from 'path';
+import {
+  normalizeHookInput,
+  isPlanMode,
+} from '../../../cli/hooks/stdin-parser.js';
+import {
+  findCodexTranscriptPath,
+  extractPlanMarkdownFromCodexTranscript,
+} from '../../../cli/hooks/codex-transcript.js';
+import { determineProjectRoot } from '../../../utils/project-root.js';
+
+describe('codex-hook-normalization', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.CODEX_SESSION_ID;
+    delete process.env.CODEX_CWD;
+    delete process.env.CODEX_HOME;
+    delete process.env.GROK_HOOK_EVENT;
+    delete process.env.GROK_WORKSPACE_ROOT;
+    delete process.env.CLAUDE_PROJECT_DIR;
+    delete process.env.SQLEW_PROJECT_ROOT;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  describe('normalizeHookInput', () => {
+    it('should normalize Codex shell_command to Bash', () => {
+      const result = normalizeHookInput({
+        hook_event_name: 'PreToolUse',
+        tool_name: 'shell_command',
+        cwd: 'C:/project',
+      });
+      assert.strictEqual(result.client, 'codex');
+      assert.strictEqual(result.tool_name, 'Bash');
+      assert.strictEqual(result.cwd, 'C:/project');
+    });
+
+    it('should normalize Codex apply_patch to Edit', () => {
+      const result = normalizeHookInput({
+        hook_event_name: 'PostToolUse',
+        tool_name: 'apply_patch',
+        cwd: 'C:/project',
+      });
+      assert.strictEqual(result.client, 'codex');
+      assert.strictEqual(result.tool_name, 'Edit');
+    });
+
+    it('should map collaboration_mode plan to permission_mode plan', () => {
+      const result = normalizeHookInput({
+        hook_event_name: 'UserPromptSubmit',
+        collaboration_mode: { mode: 'plan' },
+        cwd: 'C:/project',
+        session_id: 'sess-codex-1',
+      });
+      assert.strictEqual(result.client, 'codex');
+      assert.strictEqual(result.collaboration_mode, 'plan');
+      assert.strictEqual(result.permission_mode, 'plan');
+    });
+
+    it('should use CODEX env vars when stdin is empty', () => {
+      process.env.CODEX_SESSION_ID = 'sess-1';
+      process.env.CODEX_CWD = 'C:/project';
+
+      const result = normalizeHookInput({});
+      assert.strictEqual(result.client, 'codex');
+      assert.strictEqual(result.session_id, 'sess-1');
+      assert.strictEqual(result.cwd, 'C:/project');
+    });
+  });
+
+  describe('isPlanMode', () => {
+    it('should detect Codex plan mode via collaboration_mode', () => {
+      assert.strictEqual(
+        isPlanMode({ client: 'codex', collaboration_mode: 'plan' }),
+        true,
+      );
+    });
+
+    it('should detect Codex after normalization', () => {
+      const normalized = normalizeHookInput({
+        hook_event_name: 'UserPromptSubmit',
+        collaboration_mode_kind: 'plan',
+        cwd: 'C:/project',
+      });
+      assert.strictEqual(isPlanMode(normalized), true);
+    });
+  });
+
+  describe('findCodexTranscriptPath', () => {
+    it('should reject invalid session ids', () => {
+      assert.strictEqual(findCodexTranscriptPath('../escape'), null);
+      assert.strictEqual(findCodexTranscriptPath(''), null);
+    });
+
+    it('should find an existing local rollout transcript when present', () => {
+      const sessionId = '019e85cb-a131-7760-9a30-f164fcf83073';
+      const expected = join(
+        homedir(),
+        '.codex',
+        'sessions',
+        '2026',
+        '06',
+        '02',
+        `rollout-2026-06-02T09-46-15-${sessionId}.jsonl`,
+      );
+      const found = findCodexTranscriptPath(sessionId);
+      if (found) {
+        assert.strictEqual(found, expected);
+      }
+    });
+  });
+
+  describe('extractPlanMarkdownFromCodexTranscript', () => {
+    it('should return null for missing files', () => {
+      assert.strictEqual(
+        extractPlanMarkdownFromCodexTranscript('C:/missing/transcript.jsonl'),
+        null,
+      );
+    });
+  });
+
+  describe('determineProjectRoot', () => {
+    it('should prefer CODEX_CWD over SQLEW_PROJECT_ROOT', () => {
+      process.env.CODEX_CWD = 'C:/codex-workspace';
+      process.env.SQLEW_PROJECT_ROOT = 'C:/other';
+      assert.strictEqual(determineProjectRoot({}), 'C:/codex-workspace');
+    });
+  });
+});

--- a/src/tests/unit/hooks/codex-hook-normalization.test.ts
+++ b/src/tests/unit/hooks/codex-hook-normalization.test.ts
@@ -132,10 +132,16 @@ describe('codex-hook-normalization', () => {
   });
 
   describe('determineProjectRoot', () => {
+    // determineProjectRoot uses path.isAbsolute(), which is platform-specific:
+    // 'C:/...' is absolute only on win32. Build paths that are absolute on the
+    // current platform so the precedence assertions hold on Linux CI too.
+    const absRoot = (p: string): string => (process.platform === 'win32' ? `C:${p}` : p);
+
     it('should prefer CODEX_CWD over SQLEW_PROJECT_ROOT', () => {
-      process.env.CODEX_CWD = 'C:/codex-workspace';
-      process.env.SQLEW_PROJECT_ROOT = 'C:/other';
-      assert.strictEqual(determineProjectRoot({}), 'C:/codex-workspace');
+      const codexRoot = absRoot('/codex-workspace');
+      process.env.CODEX_CWD = codexRoot;
+      process.env.SQLEW_PROJECT_ROOT = absRoot('/other');
+      assert.strictEqual(determineProjectRoot({}), codexRoot);
     });
   });
 });

--- a/src/utils/project-root.ts
+++ b/src/utils/project-root.ts
@@ -4,6 +4,7 @@
  * Determines the project root directory with correct priority order:
  * 0. CLAUDE_PROJECT_DIR environment variable (Claude Code / Grok Build hooks)
  * 0b. GROK_WORKSPACE_ROOT environment variable (Grok Build hooks / MCP)
+ * 0c. CODEX_CWD environment variable (Codex hooks / MCP)
  * 1. SQLEW_PROJECT_ROOT environment variable (MCP client can set this)
  * 2. CLI --db-path argument (absolute path) → use dirname
  * 3. CLI --config-path argument (absolute path) → use dirname
@@ -94,6 +95,12 @@ export function determineProjectRoot(options: ProjectRootOptions = {}): string {
   const grokWorkspaceRoot = process.env.GROK_WORKSPACE_ROOT;
   if (grokWorkspaceRoot && path.isAbsolute(grokWorkspaceRoot)) {
     return grokWorkspaceRoot.replace(/\\/g, '/');
+  }
+
+  // Priority 0c: CODEX_CWD (Codex hooks inject workspace cwd)
+  const codexCwd = process.env.CODEX_CWD;
+  if (codexCwd && path.isAbsolute(codexCwd)) {
+    return codexCwd.replace(/\\/g, '/');
   }
 
   // Priority 1: SQLEW_PROJECT_ROOT environment variable


### PR DESCRIPTION
## Summary

- Add MCP hook-layer support for OpenAI Codex (v5.2.1), paired with sqlew-plugin v5.2.1 already on main
- Normalize Codex hook payloads (`shell_command`, `apply_patch`, `collaboration_mode`) to the existing Claude-shaped handlers
- Extract Plan-mode ADR patterns from Codex rollout JSONL transcripts on session stop
- Update install docs to use `codex plugin install` instead of manual sqlew-codex-skills copy

## Decision: Unify Codex integration via sqlew-plugin (same pattern as Grok Build)

Paired with [sqlew-plugin@563cadf](https://github.com/sqlew-io/sqlew-plugin/commit/563cadf). MCP owns hook normalization and transcript extraction; the plugin repo owns manifests, skills, and hook matchers.

- `src/cli/hooks/stdin-parser.ts`: Codex client detection, tool name mapping, `collaboration_mode` plan detection
- `src/cli/hooks/codex-transcript.ts`: locate `~/.codex/sessions/**/{sessionId}.jsonl` and extract Plan-mode assistant text
- `src/cli/hooks/on-prompt.ts`: initialize Codex plan session cache and inject plan enforcement
- `src/cli/hooks/on-exit-plan.ts`: materialize transcript plan text and run pattern extraction on Codex `Stop`
- `src/utils/project-root.ts`: `CODEX_CWD` support for hook project resolution
- `src/tests/unit/hooks/codex-hook-normalization.test.ts`: normalization and transcript helper coverage

## Constraint: Reuse Grok-style hook normalization instead of Codex-specific handlers

- `src/cli/hooks/on-exit-plan.ts`: Codex branch mirrors Grok plan-path caching without duplicating `plan-processor.ts`
- `src/cli/hooks/on-prompt.ts`: Grok remains passive (`UserPromptSubmit` stdout ignored); Codex uses hook injection like Claude

## Other Changes

- `docs/HOOKS_GUIDE.md`: Codex plugin install instructions and feature matrix update
- `README.md`: replace sqlew-codex manual install with plugin install steps
- `CHANGELOG.md`: document Codex hook support under existing v5.2.1 release entry

## Testing

- `npx tsc`
- `npx tsx --test --test-force-exit src/tests/unit/hooks/codex-hook-normalization.test.ts`
- `npx tsx --test --test-force-exit src/tests/unit/hooks/grok-hook-normalization.test.ts`
- Pre-commit full unit/feature/database/integration suite passed locally