### PR TITLE
feat(hermes): Hermes hook adapter for Plan-to-ADR (v5.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [5.3.0] - 2026-06-27
+
+### Added
+
+**Hermes (Claude Code / Nous) hook adapter**
+
+Hermes uses a different shell-hook wire protocol than Claude Code, Codex, and Grok Build. Without normalization, Hermes payloads (`pre_tool_call` + `terminal`, etc.) fell through to Claude passthrough and every hook handler silently no-oped. sqlew 5.3.0 adds a fourth client adapter in `stdin-parser.ts`, following the Grok/Codex pattern.
+
+- **Event mapping** — `pre_tool_call` → `PreToolUse`, `post_tool_call` → `PostToolUse`, `pre_llm_call` → `UserPromptSubmit`, `on_session_start` → `SessionStart`, `subagent_stop` → `SubagentStop`, and related lifecycle events.
+- **Tool mapping** — `terminal` → `Bash`, `write_file` → `Write`, `patch` → `Edit`, `todo` → `TodoWrite`, `delegate_task` → `Task`, `read_file` → `Read`.
+- **Detection** — `isHermesPayload()` with PascalCase guard (avoids misclassifying Claude/Codex when `HERMES_*` env vars are set in the parent shell), `extra` + env fallback, and empty-stdin env detection.
+- **Plan paths** — `.hermes/plans/*.md` recognized by `isPlanFile()`; `tool_input.path` aliased to `file_path` for Hermes file tools.
+- **Project root** — `TERMINAL_CWD` fallback in `getProjectPath()` and `determineProjectRoot()`.
+- **Output protocol** — `sendHermesContext()` for `pre_llm_call` (`{"context":"..."}`); `sendBlock()` emits `{"decision":"block","reason"}` when `HERMES_SESSION_ID` / `HERMES_HOME` / `_HERMES_GATEWAY` are set.
+- **`on-prompt`** — Every-turn plan guidance for Hermes (FULL on first prompt in session, SHORT after); Hermes has no native `permission_mode: plan`.
+- **Tests** — Unit (`hermes-hook-normalization`) and integration (`hermes-on-prompt`, `hermes-pr-adr`, `hermes-side-effect-hooks`).
+- **Docs** — [docs/HERMES_HOOKS.md](docs/HERMES_HOOKS.md) (setup, config snippet, Claude vs Hermes table); [docs/HOOKS_GUIDE.md](docs/HOOKS_GUIDE.md) Hermes section; [README.md](README.md) quick-start.
+
+### Changed
+
+- **`save` hook** — `.hermes/plans/` paths excluded from implementation-file promotion (same as `.claude/plans/`).
+
+### Plugin (sqlew-plugin v5.3.0)
+
+Install Hermes integration via the `.hermes-plugin/` bundle:
+
+```bash
+npm i -g sqlew
+hermes plugins install sqlew-io/sqlew-plugin/.hermes-plugin
+hermes plugins enable sqlew
+```
+
+The plugin merges `mcp_servers.sqlew` and shell `hooks:` into `~/.hermes/config.yaml`, copies planning skills to `~/.hermes/skills/`, and registers hooks on enable.
+
+### Upgrade
+
+```bash
+npm i -g sqlew@5.3.0
+```
+
+No database migration in this release. Existing Claude/Codex/Grok hook behavior is unchanged.
+
 ## [5.2.2] - 2026-06-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,37 +43,85 @@ npm install -g sqlew
 
 ### 2. Setup
 
-Choose the setup that matches your environment:
+Choose the setup that matches your environment. Each client has its own install and uninstall steps.
 
 #### Claude Code (Plugin)
+
+**Install:**
 
 ```bash
 claude plugin marketplace add sqlew-io/sqlew-plugin
 claude plugin install sqlew
 ```
 
-The plugin automatically configures MCP server, Skills (Plan Mode guidance), and Hooks (automatic decision capture).
+Configures MCP server, Skills (Plan Mode guidance), and Hooks (automatic decision capture).
+
+**Uninstall:**
+
+```bash
+claude plugin remove sqlew
+```
 
 #### Codex CLI (Plugin)
+
+**Install:**
 
 ```bash
 codex plugin marketplace add sqlew-io/sqlew-plugin
 codex plugin install sqlew --source sqlew-plugin
 ```
 
-After install, open `/hooks` in Codex and trust the bundled sqlew hooks. Enable Plan Mode with `collaboration_modes = true` under `[features]` in your Codex config. The plugin configures MCP server, Skills (plan mode guidance), and Hooks (plan enforcement, PR ADR guard, decision extraction). See [Hooks Guide](docs/HOOKS_GUIDE.md) for caveats (do not duplicate skills in `~/.codex/skills/` or add `[mcp_servers.sqlew]` to `config.toml`).
+After install, open `/hooks` in Codex and trust the bundled sqlew hooks. Enable Plan Mode with `collaboration_modes = true` under `[features]` in your Codex config.
+
+> Do not duplicate skills in `~/.codex/skills/` or add `[mcp_servers.sqlew]` to `config.toml` when using the plugin. See [Hooks Guide](docs/HOOKS_GUIDE.md).
+
+**Uninstall:**
+
+```bash
+codex plugin remove sqlew
+```
 
 #### Grok Build (Plugin)
 
+**Install:**
+
 ```bash
-npm install -g sqlew
 grok plugin install sqlew-io/sqlew-plugin --trust
 grok plugin update
 ```
 
-The plugin configures MCP server, Skills (plan mode guidance), and Hooks (automatic decision capture on `exit_plan_mode`). See [Hooks Guide](docs/HOOKS_GUIDE.md) for setup details and caveats (do not duplicate hooks in `~/.grok/hooks/` or `config.toml`).
+Configures MCP server, Skills (plan mode guidance), and Hooks (automatic decision capture on `exit_plan_mode`).
 
-#### Manual
+> Do not duplicate hooks in `~/.grok/hooks/` or add `[mcp_servers.sqlew]` to `~/.grok/config.toml`. See [Hooks Guide](docs/HOOKS_GUIDE.md).
+
+**Uninstall:**
+
+```bash
+grok plugin remove sqlew
+```
+
+#### Hermes (Plugin)
+
+Requires sqlew **>= 5.3.0**. Hermes uses a separate plugin bundle (`.hermes-plugin/`), not the Claude/Codex plugin manifest.
+
+**Install:**
+
+```bash
+hermes plugins install sqlew-io/sqlew-plugin/.hermes-plugin
+hermes plugins enable sqlew
+```
+
+Merges MCP + shell hooks into `~/.hermes/config.yaml` and copies planning skills to `~/.hermes/skills/`. See [Hermes Hooks Guide](docs/HERMES_HOOKS.md) for wire-protocol details and manual `config.yaml` setup.
+
+**Uninstall:**
+
+```bash
+hermes plugins remove sqlew
+```
+
+If you merged hooks manually before using the plugin, also remove `mcp_servers.sqlew` and sqlew `hooks:` entries from `~/.hermes/config.yaml`. Skills under `~/.hermes/skills/sqlew-*` are not removed automatically.
+
+#### Manual (MCP only)
 
 Add to `.mcp.json` in your project root:
 
@@ -101,7 +149,7 @@ No special commands needed — just plan your work normally, and sqlew captures 
 - **Fast Queries** — 2-50ms retrieval via SQL, even with thousands of decisions
 - **Duplicate Detection** — Three-tier similarity scoring (0-100) prevents redundant decisions
 - **Constraint Tracking** — Architectural rules and principles as first-class entities
-- **Auto-Capture** — Hooks automatically record decisions from Plan Mode (Claude Code, Codex, and Grok Build via sqlew-plugin)
+- **Auto-Capture** — Hooks automatically record decisions from Plan Mode (Claude Code, Codex, Grok Build, and Hermes via sqlew-plugin)
 - **Multi-Database** — SQLite (default), PostgreSQL, MySQL/MariaDB, or Cloud
 - **Git Worktree Ready** — Each worktree shares the same context database
 
@@ -157,7 +205,8 @@ name = "your-project-name"
 |-------|-------------|
 | [ADR Concepts](docs/ADR_CONCEPTS.md) | Architecture Decision Records explained |
 | [Configuration](docs/CONFIGURATION.md) | Config file setup, database options |
-| [Hooks Guide](docs/HOOKS_GUIDE.md) | Claude Code, Codex, and Grok Build integration |
+| [Hooks Guide](docs/HOOKS_GUIDE.md) | Claude Code, Codex, Grok Build, and Hermes integration |
+| [Hermes Hooks Guide](docs/HERMES_HOOKS.md) | Hermes-specific setup and wire-protocol notes |
 | [Cross Database](docs/CROSS_DATABASE.md) | Multi-database support |
 | [CLI Usage](docs/CLI_USAGE.md) | Database migration, export/import |
 
@@ -178,15 +227,16 @@ Support development via [GitHub Sponsors](https://github.com/sponsors/sqlew-io).
 
 ## Version
 
-Current version: **5.2.0**
+Current version: **5.3.0**
 
 See [CHANGELOG.md](CHANGELOG.md) for release history.
 
-**What's New in v5.2.0:**
+**What's New in v5.3.0:**
 
-- **Grok Build support** — Plan-to-ADR via [sqlew-plugin](https://github.com/sqlew-io/sqlew-plugin) (`grok plugin install sqlew-io/sqlew-plugin --trust`)
-- **Grok plan.md injection** — Decision/Constraint template appended on `enter_plan_mode`
-- **Hook normalization** — Single CLI hook handlers work under both Claude Code and Grok Build
+- **Hermes support** — Plan-to-ADR via [sqlew-plugin](https://github.com/sqlew-io/sqlew-plugin) `.hermes-plugin` bundle (`hermes plugins install sqlew-io/sqlew-plugin/.hermes-plugin`)
+- **Hook normalization** — Hermes `pre_tool_call` / `pre_llm_call` payloads mapped to canonical Claude-shaped events and tools
+- **Every-turn plan guidance** — `on-prompt` injects FULL/SHORT context via Hermes `pre_llm_call` (`{"context":"..."}`)
+- **`.hermes/plans/`** — Plan files written by the Hermes `plan` skill are tracked for decision extraction
 
 ## License
 

--- a/docs/HERMES_HOOKS.md
+++ b/docs/HERMES_HOOKS.md
@@ -1,0 +1,142 @@
+# Hermes Hook Setup
+
+sqlew Plan-to-ADR hooks for [Hermes](https://github.com/NousResearch/hermes-agent) (Claude Code / Nous). Requires **sqlew >= 5.3.0**.
+
+## Quick Install (recommended)
+
+Use the [sqlew-plugin](https://github.com/sqlew-io/sqlew-plugin) Hermes bundle:
+
+```bash
+npm i -g sqlew
+hermes plugins install sqlew-io/sqlew-plugin/.hermes-plugin
+hermes plugins enable sqlew
+```
+
+The plugin merges MCP + hooks into `~/.hermes/config.yaml` and copies skills to `~/.hermes/skills/`.
+
+## Manual Setup
+
+### MCP server
+
+Add to `~/.hermes/config.yaml`:
+
+```yaml
+mcp_servers:
+  sqlew:
+    command: sqlew
+    args: []
+    env: {}
+```
+
+### Shell hooks
+
+```yaml
+hooks:
+  pre_tool_call:
+    - matcher: "terminal"
+      command: "sqlew pr-adr"
+      timeout: 10
+    - matcher: "write_file|patch"
+      command: "sqlew track-plan"
+      timeout: 30
+    - matcher: "delegate_task"
+      command: "sqlew suggest"
+      timeout: 30
+  post_tool_call:
+    - matcher: "write_file|patch"
+      command: "sqlew save"
+      timeout: 30
+    - matcher: "todo"
+      command: "sqlew check-completion"
+      timeout: 30
+  pre_llm_call:
+    - command: "sqlew on-prompt"
+      timeout: 10
+  on_session_start:
+    - command: "sqlew on-session-start"
+      timeout: 30
+  subagent_stop:
+    - command: "sqlew on-subagent-stop"
+      timeout: 30
+
+hooks_auto_accept: false   # first run prompts per (event, command)
+```
+
+Matchers apply only to `pre_tool_call` and `post_tool_call`.
+
+## Verify
+
+```bash
+hermes hooks list
+hermes hooks test pre_tool_call --for-tool terminal
+hermes hooks test pre_llm_call
+```
+
+## Differences from Claude Code
+
+| Aspect | Claude / Codex / Grok | Hermes |
+|--------|----------------------|--------|
+| Hook registration | Plugin `hooks/hooks.json` | `~/.hermes/config.yaml` `hooks:` block |
+| Event names | PascalCase (`PreToolUse`) | snake_case (`pre_tool_call`) — normalized by sqlew |
+| Tool names | `Bash`, `Write`, `Edit` | `terminal`, `write_file`, `patch` — normalized by sqlew |
+| Plan mode | `permission_mode: plan` or Enter/ExitPlanMode | No native plan mode; `plan` skill writes `.hermes/plans/*.md` |
+| Context injection | `UserPromptSubmit`, `PostToolUse` | **`pre_llm_call` only** (`{"context":"..."}`) |
+| Tool blocking | PreToolUse deny JSON | **`pre_tool_call` only** (`{"decision":"block","reason"}`) |
+| Plan exit hook | `ExitPlanMode` → `on-exit-plan` | **Not available** — use `track-plan`/`save` on `.hermes/plans/` writes |
+
+## Plan-to-ADR workflow on Hermes
+
+1. **`pre_llm_call`** — sqlew injects plan guidance every turn (FULL on first prompt in session, SHORT after).
+2. **Write plan** — use the `plan` skill; files land in `.hermes/plans/*.md`.
+3. **`track-plan`** — fires on `write_file|patch` to plan paths; caches plan metadata.
+4. **`save`** — promotes decisions when implementation files are edited.
+5. **MCP tools** — agent can call `decision` / `constraint` directly per skill guidance.
+
+There is no `ExitPlanMode` equivalent. Extraction relies on plan-file writes and optional `subagent_stop`.
+
+## Hook allowlist
+
+Hermes prompts for `(event, command)` approval on first run. For CI / gateway:
+
+- `hooks_auto_accept: true` in config, or
+- `HERMES_ACCEPT_HOOKS=1`, or
+- `hermes --accept-hooks` (when supported by your entrypoint)
+
+## Optional: `post_llm_call` (Stop)
+
+sqlew's `on-stop` cleanup is not wired by default on Hermes (stdout ignored except on `pre_llm_call` / `pre_tool_call`). Add manually if needed:
+
+```yaml
+hooks:
+  post_llm_call:
+    - command: "sqlew on-stop"
+      timeout: 30
+```
+
+## Skills
+
+Copy from sqlew-plugin or install via the Hermes plugin bundle:
+
+- `sqlew-decision-format` — `📌` / `🚫` block format
+- `sqlew-plan-guidance` — suggest search + Related Context section
+- `sqlew-pr-adr` — PR body enrichment
+
+## `delegate_task` caveat
+
+Hermes `delegate_task` maps to Claude `Task`, but has no `subagent_type: Plan`. The `suggest` hook clears Plan-agent cache only — under Hermes it is mostly a no-op. Use MCP `suggest` directly in plans instead.
+
+## Uninstall
+
+**Plugin install:**
+
+```bash
+hermes plugins remove sqlew
+```
+
+Removes `~/.hermes/plugins/sqlew/`. Merged config and copied skills are **not** reverted automatically.
+
+**Full cleanup (optional):**
+
+1. Edit `~/.hermes/config.yaml` — remove `mcp_servers.sqlew` and sqlew `hooks:` entries
+2. Delete `~/.hermes/skills/sqlew-decision-format`, `sqlew-plan-guidance`, and `sqlew-pr-adr` if no longer needed
+3. `hermes gateway restart` if the gateway is running

--- a/docs/HOOKS_GUIDE.md
+++ b/docs/HOOKS_GUIDE.md
@@ -66,7 +66,7 @@ Source: https://github.com/sqlew-io/sqlew-plugin
 
 ## Grok Build
 
-sqlew-plugin provides unified support for Claude Code and Grok Build (v5.2+).
+sqlew-plugin provides unified support for Claude Code, Grok Build (v5.2+), Codex (v5.2.1+), and Hermes (v5.3.0+).
 No separate adapter is required.
 
 ```bash
@@ -97,18 +97,43 @@ grok inspect              # hooks, MCP, skills visible
 
 Source: https://github.com/sqlew-io/sqlew-plugin
 
+## Hermes (Claude Code / Nous)
+
+Requires sqlew **>= 5.3.0**. Uses the `.hermes-plugin/` bundle (not the Claude/Codex plugin manifest).
+
+**Install:**
+
+```bash
+npm i -g sqlew
+hermes plugins install sqlew-io/sqlew-plugin/.hermes-plugin
+hermes plugins enable sqlew
+```
+
+The plugin merges MCP + shell hooks into `~/.hermes/config.yaml` and copies planning skills to `~/.hermes/skills/`.
+
+See [HERMES_HOOKS.md](HERMES_HOOKS.md) for manual `config.yaml` setup, event/tool mapping, and Hermes-specific limitations.
+
+**Uninstall:**
+
+```bash
+hermes plugins remove sqlew
+```
+
+Merged `config.yaml` entries and skills under `~/.hermes/skills/sqlew-*` are not removed automatically.
+
 ## What Gets Configured
 
-| Feature | Claude Code | Codex | Grok Build |
-|---------|-------------|-------|------------|
-| Install | `claude plugin install` | `codex plugin install` | `grok plugin install` |
-| MCP server | Plugin `.mcp.json` | Plugin `.mcp.json` | Plugin `.mcp.json` |
-| Plan-to-ADR | Skills + Hooks | Skills + Hooks | Skills + Hooks |
-| PR enrichment | Skill + Hook | Skill + Hook | Skill + Hook |
-| Decision format guidance | Skill (sqlew-decision-format) | Skill (sqlew-decision-format) | Skill (sqlew-decision-format) |
+| Feature | Claude Code | Codex | Grok Build | Hermes |
+|---------|-------------|-------|------------|--------|
+| Install | `claude plugin install` | `codex plugin install` | `grok plugin install` | `hermes plugins install …/.hermes-plugin` |
+| MCP server | Plugin `.mcp.json` | Plugin `.mcp.json` | Plugin `.mcp.json` | `config.yaml` merge |
+| Plan-to-ADR | Skills + Hooks | Skills + Hooks | Skills + Hooks | Skills + shell hooks |
+| PR enrichment | Skill + Hook | Skill + Hook | Skill + Hook | Hook (`pr-adr`) |
+| Decision format guidance | Skill (sqlew-decision-format) | Skill (sqlew-decision-format) | Skill (sqlew-decision-format) | Skill |
 
 ## Version History
 
+- **v5.3.0**: Hermes hook adapter (event/tool normalization, `.hermes/plans`, `pre_llm_call` context injection)
 - **v5.2.1**: Codex plugin support via sqlew-plugin (`.codex-plugin`, marketplace, hook normalization, transcript-based plan extraction)
 - **v5.2.0**: Grok Build support via sqlew-plugin (hook normalization, Grok plan path, skills-based plan guidance)
 - **v5.0.0**: Plugin-first architecture (sqlew-plugin for Claude Code; manual sqlew-codex-skills for Codex — now deprecated)

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "sqlew",
   "display_name": "sqlew - Context Manager for AI Agents",
-  "version": "5.2.2",
+  "version": "5.3.0",
   "description": "Token-efficient context management for AI coding agents. Record architectural decisions, constraints, and maintain project knowledge across sessions. Supports SQLite local storage and sqlew.io cloud backend.",
   "author": {
     "name": "sqlew.io",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlew",
-  "version": "5.2.2",
+  "version": "5.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlew",
-      "version": "5.2.2",
+      "version": "5.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.21.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sqlew",
   "description": "Automated ADR (Architecture Decision Records) for AI Coding Agents - MCP server with SQL-backed decision repository",
-  "version": "5.2.2",
+  "version": "5.3.0",
   "main": "dist/index.js",
   "type": "module",
   "bin": {

--- a/src/cli/hooks/on-prompt.ts
+++ b/src/cli/hooks/on-prompt.ts
@@ -20,7 +20,7 @@
  */
 
 import { randomUUID } from 'crypto';
-import { readStdinJson, isPlanMode, getProjectPath } from './stdin-parser.js';
+import { readStdinJson, isPlanMode, getProjectPath, sendHermesContext } from './stdin-parser.js';
 import { loadCurrentPlan, saveCurrentPlan, type CurrentPlanInfo } from '../../config/global-config.js';
 import { findCodexTranscriptPath } from './codex-transcript.js';
 
@@ -84,6 +84,38 @@ export async function onPromptCommand(): Promise<void> {
     // Grok Build: UserPromptSubmit is a passive hook — stdout is ignored.
     // Plan mode guidance is delivered via plugin skills instead.
     if (input.client === 'grok') {
+      return;
+    }
+
+    // Hermes: pre_llm_call is the only context-injection point and there is no
+    // plan permission mode. Inject FULL guidance once per session, SHORT after.
+    if (input.client === 'hermes') {
+      const hermesProjectPath = getProjectPath(input);
+      if (!hermesProjectPath) {
+        sendHermesContext(ENFORCEMENT_FULL);
+        return;
+      }
+
+      let hermesPlanInfo = loadCurrentPlan(hermesProjectPath);
+      if (!hermesPlanInfo || !hermesPlanInfo.enforcement_shown_at) {
+        sendHermesContext(ENFORCEMENT_FULL);
+        if (hermesPlanInfo) {
+          hermesPlanInfo.enforcement_shown_at = new Date().toISOString();
+          saveCurrentPlan(hermesProjectPath, hermesPlanInfo);
+        } else {
+          const info: CurrentPlanInfo = {
+            plan_id: randomUUID(),
+            plan_file: 'hermes-plan.md',
+            plan_updated_at: new Date().toISOString(),
+            recorded: false,
+            decision_pending: true,
+            enforcement_shown_at: new Date().toISOString(),
+          };
+          saveCurrentPlan(hermesProjectPath, info);
+        }
+      } else {
+        sendHermesContext(ENFORCEMENT_SHORT);
+      }
       return;
     }
 

--- a/src/cli/hooks/save.ts
+++ b/src/cli/hooks/save.ts
@@ -39,7 +39,7 @@ function isImplementationFile(filePath: string | undefined): boolean {
   if (normalized.endsWith('.md')) return false;
 
   // Exclude plan files explicitly
-  if (normalized.includes('.claude/plans/')) return false;
+  if (normalized.includes('.claude/plans/') || normalized.includes('.hermes/plans/')) return false;
 
   // Exclude documentation directories
   if (normalized.includes('/docs/')) return false;

--- a/src/cli/hooks/stdin-parser.ts
+++ b/src/cli/hooks/stdin-parser.ts
@@ -24,6 +24,8 @@ import { resolvePlanPath } from './plan-pattern-extractor.js';
 export interface ToolInput {
   /** File path (Edit, Write tools) */
   file_path?: string;
+  /** File path used by Hermes file tools (write_file/read_file/patch) */
+  path?: string;
   /** Command (Bash tool) */
   command?: string;
   /** Description (Task tool) */
@@ -92,8 +94,8 @@ export interface HookInput {
   reason?: 'clear' | 'logout' | 'prompt_input_exit' | 'other';
   /** Codex collaboration mode (e.g. plan, default). */
   collaboration_mode?: string;
-  /** Originating client, set by normalizeHookInput() (e.g., 'grok', 'codex'). undefined = Claude/native. */
-  client?: 'grok' | 'codex' | 'claude';
+  /** Originating client, set by normalizeHookInput() (e.g., 'grok', 'codex', 'hermes'). undefined = Claude/native. */
+  client?: 'grok' | 'codex' | 'claude' | 'hermes';
 }
 
 /**
@@ -186,6 +188,112 @@ const CODEX_TOOL_MAP: Record<string, string> = {
 
 const CODEX_NATIVE_TOOLS = new Set(Object.keys(CODEX_TOOL_MAP));
 
+/**
+ * Hermes (Claude Code / Nous) shell-hook event names (snake_case) →
+ * sqlew canonical (Claude PascalCase) event names.
+ *
+ * Hermes has no dedicated UserPromptSubmit event; pre_llm_call fires at the
+ * same point and is the only context-injection hook, so we map it to
+ * UserPromptSubmit. post_llm_call is the closest analog to Claude's Stop.
+ */
+const HERMES_EVENT_MAP: Record<string, HookInput['hook_event_name']> = {
+  pre_tool_call: 'PreToolUse',
+  post_tool_call: 'PostToolUse',
+  pre_llm_call: 'UserPromptSubmit',
+  post_llm_call: 'Stop',
+  on_session_start: 'SessionStart',
+  on_session_end: 'SessionEnd',
+  on_session_finalize: 'SessionEnd',
+  subagent_stop: 'SubagentStop',
+  subagent_start: 'PreToolUse',
+};
+
+/**
+ * Hermes built-in tool names → sqlew canonical (Claude) tool names.
+ * Only the names sqlew's hook handlers branch on need mapping; unknown
+ * names pass through unchanged.
+ */
+const HERMES_TOOL_MAP: Record<string, string> = {
+  terminal: 'Bash',
+  write_file: 'Write',
+  patch: 'Edit',
+  read_file: 'Read',
+  todo: 'TodoWrite',
+  delegate_task: 'Task',
+};
+
+const HERMES_NATIVE_TOOLS = new Set(Object.keys(HERMES_TOOL_MAP));
+const HERMES_NATIVE_EVENTS = new Set(Object.keys(HERMES_EVENT_MAP));
+
+function isHermesPayload(raw: Record<string, unknown>): boolean {
+  const event = raw.hook_event_name as string | undefined;
+  if (event && HERMES_NATIVE_EVENTS.has(event)) {
+    return true;
+  }
+
+  const tool = raw.tool_name as string | undefined;
+  if (tool && HERMES_NATIVE_TOOLS.has(tool)) {
+    return true;
+  }
+
+  // Claude/Codex use PascalCase event names; do not classify as Hermes even when
+  // HERMES_* env vars are set in the parent shell (common on dev machines).
+  if (event && /^[A-Z]/.test(event)) {
+    return false;
+  }
+
+  const hasHermesEnv = !!(
+    process.env.HERMES_SESSION_ID ||
+    process.env.HERMES_HOME ||
+    process.env._HERMES_GATEWAY
+  );
+
+  if (raw.extra && typeof raw.extra === 'object' && hasHermesEnv) {
+    return true;
+  }
+
+  // Env-only fallback for empty or lifecycle payloads spawned by Hermes hooks.
+  if (hasHermesEnv && !event && !tool) {
+    // Empty stdin is ambiguous — prefer Codex/Grok env when those clients spawned the hook.
+    if (process.env.CODEX_SESSION_ID || process.env.CODEX_CWD || process.env.CODEX_HOME) {
+      return false;
+    }
+    if (process.env.GROK_HOOK_EVENT || process.env.GROK_WORKSPACE_ROOT) {
+      return false;
+    }
+    return true;
+  }
+
+  return false;
+}
+
+function normalizeHermesPayload(raw: Record<string, unknown>): HookInput {
+  const rawEvent = raw.hook_event_name as string | undefined;
+  const rawTool = raw.tool_name as string | undefined;
+  const toolInput = (raw.tool_input as ToolInput | undefined) ?? undefined;
+
+  const normalizedToolInput: ToolInput | undefined = toolInput
+    ? {
+        ...toolInput,
+        file_path:
+          (toolInput.file_path as string | undefined) ??
+          (toolInput.path as string | undefined),
+      }
+    : undefined;
+
+  return {
+    ...(raw as HookInput),
+    client: 'hermes',
+    hook_event_name: rawEvent
+      ? HERMES_EVENT_MAP[rawEvent] || (rawEvent as HookInput['hook_event_name'])
+      : (raw.hook_event_name as HookInput['hook_event_name']),
+    tool_name: rawTool ? HERMES_TOOL_MAP[rawTool] || rawTool : (raw.tool_name as string | undefined),
+    tool_input: normalizedToolInput,
+    session_id: (raw.session_id || process.env.HERMES_SESSION_ID) as string | undefined,
+    cwd: (raw.cwd || process.env.TERMINAL_CWD) as string | undefined,
+  };
+}
+
 function extractCollaborationMode(raw: Record<string, unknown>): string | undefined {
   const direct = raw.collaboration_mode ?? raw.collaborationMode;
   if (typeof direct === 'string') {
@@ -267,6 +375,8 @@ export function normalizeHookInput(raw: unknown): HookInput {
 
   if (isGrok) {
     // Grok branch below
+  } else if (isHermesPayload(r)) {
+    return normalizeHermesPayload(r);
   } else if (isCodexPayload(r)) {
     return normalizeCodexPayload(r);
   } else {
@@ -427,8 +537,20 @@ export function sendBlock(reason: string): void {
   if (process.env.GROK_HOOK_EVENT || process.env.GROK_WORKSPACE_ROOT) {
     console.log(JSON.stringify({ decision: 'deny', reason }));
   }
+  // Hermes: pre_tool_call block is read from stdout JSON (decision/block shape).
+  if (process.env.HERMES_SESSION_ID || process.env.HERMES_HOME || process.env._HERMES_GATEWAY) {
+    console.log(JSON.stringify({ decision: 'block', reason }));
+  }
   console.error(reason);
   process.exit(2);
+}
+
+/**
+ * Emit a Hermes shell-hook context-injection response.
+ * Hermes honors {"context": "..."} only on pre_llm_call.
+ */
+export function sendHermesContext(context: string): void {
+  console.log(JSON.stringify({ context }));
 }
 
 /**
@@ -499,7 +621,7 @@ export function isPlanMode(input: HookInput): boolean {
  *
  * Plan files can be in:
  * - Global: ~/.claude/plans/*.md (e.g., C:/Users/xxx/.claude/plans/my-plan.md)
- * - Project: .claude/plans/*.md (relative path)
+ * - Project: .claude/plans/*.md or .hermes/plans/*.md (relative path)
  *
  * @param input - Hook input
  * @returns true if the tool is operating on a plan file
@@ -513,10 +635,9 @@ export function isPlanFile(input: HookInput): boolean {
   // Normalize path separators for cross-platform support
   const normalizedPath = filePath.replace(/\\/g, '/');
 
-  // Match both global and project-local plan paths:
-  // - Global: /Users/xxx/.claude/plans/foo.md, C:/Users/xxx/.claude/plans/foo.md
-  // - Project: .claude/plans/foo.md
-  return /[/\\]?\.claude\/plans\/[^/]+\.md$/.test(normalizedPath);
+  // Match global + project-local plan paths for Claude (.claude/plans/) and
+  // Hermes (.hermes/plans/).
+  return /[/\\]?\.(claude|hermes)\/plans\/[^/]+\.md$/.test(normalizedPath);
 }
 
 /**
@@ -546,7 +667,8 @@ export function getProjectPath(input: HookInput): string | undefined {
     input.cwd ||
     process.env.CLAUDE_PROJECT_DIR ||
     process.env.CODEX_CWD ||
-    process.env.GROK_WORKSPACE_ROOT
+    process.env.GROK_WORKSPACE_ROOT ||
+    process.env.TERMINAL_CWD
   );
 }
 

--- a/src/tests/integration/hermes-on-prompt.test.ts
+++ b/src/tests/integration/hermes-on-prompt.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Hermes on-prompt integration tests
+ *
+ * @since v5.3.0
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'path';
+
+const projectRoot = join(import.meta.dirname, '../../..');
+const distEntry = join(projectRoot, 'dist/index.js');
+
+function runHook(cmd: string, payload: object, env: Record<string, string> = {}): string {
+  return execFileSync('node', [distEntry, cmd], {
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+    cwd: projectRoot,
+    env: { ...process.env, ...env },
+  });
+}
+
+describe('on-prompt (Hermes)', () => {
+  it('emits {context} JSON for a Hermes pre_llm_call', () => {
+    assert.ok(existsSync(distEntry), 'dist/index.js missing — run npm run build first');
+    const out = runHook(
+      'on-prompt',
+      {
+        hook_event_name: 'pre_llm_call',
+        cwd: projectRoot,
+        session_id: 's1',
+        extra: { user_message: 'plan a feature' },
+      },
+      { HERMES_SESSION_ID: 's1' },
+    );
+    const parsed = JSON.parse(out.trim());
+    assert.ok(typeof parsed.context === 'string' && parsed.context.includes('sqlew'));
+  });
+});

--- a/src/tests/integration/hermes-pr-adr.test.ts
+++ b/src/tests/integration/hermes-pr-adr.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Hermes pr-adr integration tests
+ *
+ * @since v5.3.0
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'path';
+
+const projectRoot = join(import.meta.dirname, '../../..');
+const distEntry = join(projectRoot, 'dist/index.js');
+
+describe('pr-adr (Hermes)', () => {
+  it('blocks gh pr create without ADR markers under Hermes', () => {
+    assert.ok(existsSync(distEntry), 'dist/index.js missing — run npm run build first');
+    let out = '';
+    try {
+      out = execFileSync('node', [distEntry, 'pr-adr'], {
+        input: JSON.stringify({
+          hook_event_name: 'pre_tool_call',
+          tool_name: 'terminal',
+          tool_input: { command: 'gh pr create --title x --body "no markers"' },
+          cwd: projectRoot,
+        }),
+        encoding: 'utf8',
+        cwd: projectRoot,
+        env: { ...process.env, HERMES_SESSION_ID: 's1' },
+      });
+    } catch (e: unknown) {
+      const err = e as { stdout?: Buffer | string };
+      out = (err.stdout || '').toString();
+    }
+    const parsed = JSON.parse(out.trim().split('\n').pop()!);
+    assert.strictEqual(parsed.decision, 'block');
+  });
+});

--- a/src/tests/integration/hermes-side-effect-hooks.test.ts
+++ b/src/tests/integration/hermes-side-effect-hooks.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Hermes side-effect hook integration tests
+ *
+ * @since v5.3.0
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'path';
+import { areAllTodosCompleted, normalizeHookInput } from '../../cli/hooks/stdin-parser.js';
+
+const projectRoot = join(import.meta.dirname, '../../..');
+const distEntry = join(projectRoot, 'dist/index.js');
+
+describe('hermes side-effect hooks', () => {
+  it('normalizes Hermes write_file for track-plan matching', () => {
+    const input = normalizeHookInput({
+      hook_event_name: 'pre_tool_call',
+      tool_name: 'write_file',
+      tool_input: { path: '.hermes/plans/2026-06-27_test.md' },
+      cwd: projectRoot,
+      extra: {},
+    });
+    assert.strictEqual(input.tool_name, 'Write');
+    assert.strictEqual(input.tool_input?.file_path, '.hermes/plans/2026-06-27_test.md');
+  });
+
+  it('does not treat cancelled todos as all completed', () => {
+    const input = normalizeHookInput({
+      hook_event_name: 'post_tool_call',
+      tool_name: 'todo',
+      tool_input: {
+        todos: [
+          { content: 'a', status: 'completed' },
+          { content: 'b', status: 'cancelled' },
+        ],
+      },
+      cwd: projectRoot,
+      extra: {},
+    });
+    assert.strictEqual(areAllTodosCompleted(input), false);
+  });
+
+  it('runs save hook with exit 0 for Hermes write_file payload', () => {
+    assert.ok(existsSync(distEntry), 'dist/index.js missing — run npm run build first');
+    const out = execFileSync('node', [distEntry, 'save'], {
+      input: JSON.stringify({
+        hook_event_name: 'post_tool_call',
+        tool_name: 'write_file',
+        tool_input: { path: 'README.md' },
+        cwd: projectRoot,
+      }),
+      encoding: 'utf8',
+      cwd: projectRoot,
+      env: { ...process.env, HERMES_SESSION_ID: 's1' },
+    });
+    assert.ok(out.includes('continue') || out.trim() === '' || out.includes('hookSpecificOutput'));
+  });
+});

--- a/src/tests/unit/hooks/codex-hook-normalization.test.ts
+++ b/src/tests/unit/hooks/codex-hook-normalization.test.ts
@@ -29,6 +29,9 @@ describe('codex-hook-normalization', () => {
     delete process.env.GROK_WORKSPACE_ROOT;
     delete process.env.CLAUDE_PROJECT_DIR;
     delete process.env.SQLEW_PROJECT_ROOT;
+    delete process.env.HERMES_SESSION_ID;
+    delete process.env.HERMES_HOME;
+    delete process.env._HERMES_GATEWAY;
   });
 
   afterEach(() => {

--- a/src/tests/unit/hooks/hermes-hook-normalization.test.ts
+++ b/src/tests/unit/hooks/hermes-hook-normalization.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Hermes Hook Normalization Unit Tests
+ *
+ * @since v5.3.0
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import {
+  normalizeHookInput,
+  isPlanMode,
+  isPlanFile,
+  getProjectPath,
+} from '../../../cli/hooks/stdin-parser.js';
+
+describe('hermes-hook-normalization', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.CODEX_SESSION_ID;
+    delete process.env.CODEX_CWD;
+    delete process.env.CODEX_HOME;
+    delete process.env.GROK_HOOK_EVENT;
+    delete process.env.GROK_WORKSPACE_ROOT;
+    delete process.env.HERMES_SESSION_ID;
+    delete process.env.HERMES_HOME;
+    delete process.env._HERMES_GATEWAY;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  describe('normalizeHookInput', () => {
+    it('should map Hermes pre_tool_call + terminal to PreToolUse + Bash', () => {
+      const result = normalizeHookInput({
+        hook_event_name: 'pre_tool_call',
+        tool_name: 'terminal',
+        tool_input: { command: 'gh pr create' },
+        session_id: 'sess-h1',
+        cwd: 'C:/project',
+        extra: { task_id: 't1' },
+      });
+      assert.strictEqual(result.client, 'hermes');
+      assert.strictEqual(result.hook_event_name, 'PreToolUse');
+      assert.strictEqual(result.tool_name, 'Bash');
+      assert.strictEqual(result.cwd, 'C:/project');
+      assert.strictEqual(result.session_id, 'sess-h1');
+    });
+
+    it('should map Hermes post_tool_call + write_file to PostToolUse + Write', () => {
+      const result = normalizeHookInput({
+        hook_event_name: 'post_tool_call',
+        tool_name: 'write_file',
+        tool_input: { path: 'src/foo.ts' },
+        cwd: 'C:/project',
+      });
+      assert.strictEqual(result.client, 'hermes');
+      assert.strictEqual(result.hook_event_name, 'PostToolUse');
+      assert.strictEqual(result.tool_name, 'Write');
+      assert.strictEqual(result.tool_input?.file_path, 'src/foo.ts');
+    });
+
+    it('should map Hermes patch to Edit and todo to TodoWrite', () => {
+      assert.strictEqual(
+        normalizeHookInput({ hook_event_name: 'post_tool_call', tool_name: 'patch', cwd: 'C:/p' }).tool_name,
+        'Edit',
+      );
+      assert.strictEqual(
+        normalizeHookInput({ hook_event_name: 'post_tool_call', tool_name: 'todo', cwd: 'C:/p' }).tool_name,
+        'TodoWrite',
+      );
+    });
+
+    it('should map pre_llm_call to UserPromptSubmit', () => {
+      const result = normalizeHookInput({
+        hook_event_name: 'pre_llm_call',
+        cwd: 'C:/project',
+        session_id: 'sess-h2',
+        extra: { user_message: 'do the thing' },
+      });
+      assert.strictEqual(result.client, 'hermes');
+      assert.strictEqual(result.hook_event_name, 'UserPromptSubmit');
+    });
+
+    it('should detect Hermes via env when stdin lacks tool fields', () => {
+      process.env.HERMES_SESSION_ID = 'sess-env';
+      const result = normalizeHookInput({ hook_event_name: 'on_session_start', cwd: 'C:/p' });
+      assert.strictEqual(result.client, 'hermes');
+      assert.strictEqual(result.hook_event_name, 'SessionStart');
+    });
+
+    it('should not misclassify a Claude payload as Hermes', () => {
+      const result = normalizeHookInput({
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+      });
+      assert.notStrictEqual(result.client, 'hermes');
+      assert.strictEqual(result.tool_name, 'Bash');
+    });
+  });
+
+  describe('isPlanMode (Hermes)', () => {
+    it('should return false for Hermes (no native plan permission mode)', () => {
+      const result = normalizeHookInput({
+        hook_event_name: 'pre_llm_call',
+        cwd: 'C:/project',
+        extra: { user_message: 'plan something' },
+      });
+      assert.strictEqual(isPlanMode(result), false);
+    });
+  });
+
+  describe('hermes plan-file + project path', () => {
+    it('should recognize .hermes/plans/*.md as a plan file', () => {
+      assert.strictEqual(
+        isPlanFile({ tool_input: { file_path: 'C:/proj/.hermes/plans/2026-06-27_x.md' } }),
+        true,
+      );
+    });
+
+    it('should still recognize .claude/plans/*.md (no regression)', () => {
+      assert.strictEqual(
+        isPlanFile({ tool_input: { file_path: '.claude/plans/foo.md' } }),
+        true,
+      );
+    });
+
+    it('should resolve project path from Hermes cwd', () => {
+      assert.strictEqual(getProjectPath({ client: 'hermes', cwd: 'C:/proj' }), 'C:/proj');
+    });
+  });
+});

--- a/src/utils/project-root.ts
+++ b/src/utils/project-root.ts
@@ -5,6 +5,7 @@
  * 0. CLAUDE_PROJECT_DIR environment variable (Claude Code / Grok Build hooks)
  * 0b. GROK_WORKSPACE_ROOT environment variable (Grok Build hooks / MCP)
  * 0c. CODEX_CWD environment variable (Codex hooks / MCP)
+ * 0d. TERMINAL_CWD environment variable (Hermes hooks)
  * 1. SQLEW_PROJECT_ROOT environment variable (MCP client can set this)
  * 2. CLI --db-path argument (absolute path) → use dirname
  * 3. CLI --config-path argument (absolute path) → use dirname
@@ -101,6 +102,12 @@ export function determineProjectRoot(options: ProjectRootOptions = {}): string {
   const codexCwd = process.env.CODEX_CWD;
   if (codexCwd && path.isAbsolute(codexCwd)) {
     return codexCwd.replace(/\\/g, '/');
+  }
+
+  // Priority 0d: TERMINAL_CWD (Hermes shell hooks inject workspace cwd)
+  const terminalCwd = process.env.TERMINAL_CWD;
+  if (terminalCwd && path.isAbsolute(terminalCwd)) {
+    return terminalCwd.replace(/\\/g, '/');
   }
 
   // Priority 1: SQLEW_PROJECT_ROOT environment variable


### PR DESCRIPTION
## Summary

- Add Hermes (Claude Code / Nous) as a fourth hook client adapter in `stdin-parser.ts`
- Normalize Hermes shell-hook payloads (`pre_tool_call`, `pre_llm_call`, `terminal`, `write_file`, …) to canonical Claude-shaped events/tools so existing hook handlers work unchanged
- Emit Hermes-specific stdout (`{"context":...}` on `pre_llm_call`, `{"decision":"block",...}` on `pre_tool_call`)
- Recognize `.hermes/plans/*.md` for Plan-to-ADR tracking
- Bump version to **5.3.0**

Pairs with [sqlew-plugin@735d08c](https://github.com/sqlew-io/sqlew-plugin/commit/735d08c) (`.hermes-plugin/` bundle pushed to `main`).

## Architecture Decisions

### Hermes adapter follows Grok/Codex normalization pattern (extend stdin-parser, not per-hook forks)

- `src/cli/hooks/stdin-parser.ts`: `HERMES_EVENT_MAP`, `HERMES_TOOL_MAP`, `isHermesPayload()`, `normalizeHermesPayload()`, routing order Grok → Hermes → Codex → Claude passthrough
- `src/tests/unit/hooks/hermes-hook-normalization.test.ts`: event/tool mapping, plan path, PascalCase guard against misclassification when `HERMES_*` env is set in parent shell

**Rationale:** Hermes uses snake_case events and different tool names; without normalization every handler silently no-ops. A single adapter layer keeps `save`, `track-plan`, `pr-adr`, etc. unchanged.

### Plan guidance via every-turn `pre_llm_call` injection (no native plan permission mode)

- `src/cli/hooks/on-prompt.ts`: `client === 'hermes'` branch — FULL once per session, SHORT after
- `sendHermesContext()` in `stdin-parser.ts`

**Rationale:** Hermes has no `permission_mode: plan` or `ExitPlanMode`. `pre_llm_call` is the only context-injection hook Hermes honors on stdout.

### Output wire protocol split by client

- `sendHermesContext()` — `{"context":"..."}` for `pre_llm_call`
- `sendBlock()` — adds `{"decision":"block","reason"}` when `HERMES_*` env present (alongside existing Grok `deny` JSON)

**Rationale:** Hermes ignores Claude `additionalContext` / `continue` JSON on most events.

## Other Changes

- `src/cli/hooks/save.ts`: exclude `.hermes/plans/` from implementation-file promotion
- `src/utils/project-root.ts`: `TERMINAL_CWD` fallback for Hermes hooks
- `docs/HERMES_HOOKS.md`: setup, config snippet, Claude vs Hermes table, per-client uninstall
- `docs/HOOKS_GUIDE.md`, `README.md`: Hermes sections with separate install/uninstall per client
- `CHANGELOG.md`: 5.3.0 release notes
- Integration tests: `hermes-on-prompt`, `hermes-pr-adr`, `hermes-side-effect-hooks`
- `codex-hook-normalization.test.ts`: clear `HERMES_*` env in `beforeEach` for isolation

## Testing

```bash
npm run build
npm test
```

Pre-commit hook ran full test suite on commit (pass).