### PR TITLE
feat(project): per-call project resolution for desktop AI agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [5.3.1] - 2026-06-29
+
+### Added
+
+**Tool-call-level project targeting for desktop AI agents**
+
+Desktop AI agents (Claude Desktop, Hermes Desktop, ...) spawn the MCP server from a fixed cwd such as the user home folder, so sqlew's startup-time project detection cannot identify the active project. This release extends project resolution from "once per process" to "per tool call" without breaking any existing path.
+
+- **`_sqlew_project` parameter** — Reserved per-call scope accepted by `decision`, `constraint`, `suggest`, and `queue`. Targets a project by `root` (absolute repo path), `name`, or `ref` (e.g. `sqlew_proj_3`); overrides startup detection for that call only. Resolution is implemented with `AsyncLocalStorage` (`runWithProjectScope` in `project-context.ts`), so it is concurrency-safe and required no changes to the ~25 internal `getProjectContext()` call sites.
+- **`project` tool** — New MCP tool with actions `current` / `resolve` / `list` / `validate`. Desktop flow: call `project.resolve { root }` once, then pass `_sqlew_project: { ref }` on subsequent calls.
+- **Pollution guard (P0)** — When the server is launched from an ambiguous directory (user home or a system directory) with no explicit project signal, sqlew no longer auto-registers a directory-name project or writes `config.toml`. The context is left *unbound*; project-scoped writes/reads fail-closed with `SQLEW_PROJECT_REQUIRED` until a project is specified, while `help` / `example` / `use_case` / `project` remain usable.
+
+### Compatibility
+
+- Fully backward compatible. With `_sqlew_project` omitted and any explicit signal present (`CLAUDE_PROJECT_DIR`, `GROK_WORKSPACE_ROOT`, `CODEX_CWD`, `TERMINAL_CWD`, `SQLEW_PROJECT_ROOT`, `--db-path`, `--config-path`, or a config `database.path`), or a normal repo-cwd launch, behavior is unchanged.
+- No database schema change (no migration). `m_projects.name` remains unique; a name that already exists with a different root is rejected on writes (`SQLEW_PROJECT_NAME_COLLISION`).
+- The existing read-only `_reference_project` parameter is unchanged.
+
+---
+
 ## [5.3.0] - 2026-06-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -217,9 +217,9 @@ name = "your-project-name"
 
 ### MCP Tools
 
-7 action-based tools: `decision`, `constraint`, `suggest`, `help`, `example`, `use_case`, `queue`
+8 action-based tools: `decision`, `constraint`, `project`, `suggest`, `help`, `example`, `use_case`, `queue`
 
-All tools support `action: "help"` for documentation.
+All tools support `action: "help"` for documentation. The `project` tool targets a project per call for desktop AI agents (Claude Desktop, Hermes Desktop) — see [Shared Database](docs/SHARED_DATABASE.md).
 
 ## Support
 

--- a/docs/SHARED_DATABASE.md
+++ b/docs/SHARED_DATABASE.md
@@ -89,6 +89,66 @@ path = ".sqlew/sqlew.db"    # project-local database
 
 Project-level config always overrides global config, so you can use the global shared database by default and opt specific projects out as needed.
 
+## Desktop AI Agents (Claude Desktop / Hermes Desktop)
+
+CLI-based agents (Claude Code, Codex, Grok Build, Hermes hooks) launch the MCP server in your project's working directory or inject a workspace environment variable, so sqlew detects the correct project automatically. Desktop apps are different: they spawn the MCP server from a fixed cwd (often the user home folder), so the launch directory does not identify which project you are working on.
+
+sqlew handles this in two ways.
+
+### 1. Pollution guard (automatic)
+
+If the server starts from an ambiguous directory (the user home folder or a system directory) with no explicit project signal, sqlew does **not** invent a project from the folder name or write a `config.toml` there. The session is left **unbound**. Project-scoped tools then fail-closed rather than writing decisions to the wrong place:
+
+```json
+{
+  "error": "SQLEW_PROJECT_REQUIRED",
+  "message": "sqlew has no bound project ... Pass _sqlew_project.root or .name on this call, or call the \"project\" tool (action: resolve) first to obtain a ref."
+}
+```
+
+`help`, `example`, `use_case`, and the `project` tool stay usable so the agent can recover.
+
+### 2. Per-call project targeting
+
+Pass the reserved `_sqlew_project` parameter on `decision`, `constraint`, `suggest`, and `queue` calls to target a specific project for that call. It accepts a `root` (absolute repo path), a `name`, or a `ref`:
+
+```json
+{
+  "action": "set",
+  "key": "auth/method",
+  "value": "JWT with refresh",
+  "_sqlew_project": { "root": "C:/Users/me/RustroverProjects/mcp-sqlew" }
+}
+```
+
+The recommended desktop flow uses the `project` tool to resolve once and reuse a stable `ref`:
+
+```json
+// 1) Resolve the project (creates it if missing when given a root)
+{ "action": "resolve", "root": "C:/Users/me/RustroverProjects/mcp-sqlew" }
+// -> { "project": { ..., "ref": "sqlew_proj_3" }, "usage": { "_sqlew_project": { "ref": "sqlew_proj_3" } } }
+
+// 2) Reuse the ref on subsequent calls
+{ "action": "set", "key": "...", "value": "...", "_sqlew_project": { "ref": "sqlew_proj_3" } }
+```
+
+`project` tool actions: `current` (active project or unbound status), `resolve` (resolve/register, returns a ref), `list` (all registered projects), `validate` (read-only check).
+
+### Single-project shortcut (env var)
+
+If a desktop server instance only ever works on one project, set `SQLEW_PROJECT_ROOT` in the MCP server's `env` block. This counts as an explicit signal, so the session binds normally and `_sqlew_project` is not needed:
+
+```json
+{
+  "mcpServers": {
+    "sqlew-mcp-sqlew": {
+      "command": "sqlew",
+      "env": { "SQLEW_PROJECT_ROOT": "C:/Users/me/RustroverProjects/mcp-sqlew" }
+    }
+  }
+}
+```
+
 ## FAQ
 
 ### Can I still use project-local databases?
@@ -106,3 +166,7 @@ No change. External database connections configured in `config.toml` work exactl
 ### Is data shared between projects?
 
 Yes, all projects using the default global database share the same `sqlew-shared.db` file. Each project's data is scoped by `project_id`, so there's no data mixing. This is the same model used when multiple projects connect to a shared MySQL/PostgreSQL instance.
+
+### My desktop agent writes to the wrong project (or none). What do I do?
+
+Desktop apps launch the MCP server from a fixed cwd, so it can't detect your project. Either set `SQLEW_PROJECT_ROOT` in the server's `env` (single-project), or pass `_sqlew_project` per call / use the `project` tool to resolve a `ref` (multi-project). See [Desktop AI Agents](#desktop-ai-agents-claude-desktop--hermes-desktop) above.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "sqlew",
   "display_name": "sqlew - Context Manager for AI Agents",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Token-efficient context management for AI coding agents. Record architectural decisions, constraints, and maintain project knowledge across sessions. Supports SQLite local storage and sqlew.io cloud backend.",
   "author": {
     "name": "sqlew.io",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlew",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlew",
-      "version": "5.3.0",
+      "version": "5.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.21.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sqlew",
   "description": "Automated ADR (Architecture Decision Records) for AI Coding Agents - MCP server with SQL-backed decision repository",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "main": "dist/index.js",
   "type": "module",
   "bin": {

--- a/src/backend/local-backend.ts
+++ b/src/backend/local-backend.ts
@@ -33,7 +33,36 @@ import {
   listQueue, clearQueue, removeFromQueue
 } from '../tools/queue/index.js';
 import { getHelpLoader } from '../help-loader.js';
-import { ProjectContext } from '../utils/project-context.js';
+import {
+  projectCurrent, projectResolve, projectList, projectValidate,
+  projectHelp, projectExample
+} from '../tools/project/index.js';
+import {
+  ProjectContext, getProjectContext, runWithProjectScope
+} from '../utils/project-context.js';
+import {
+  resolveProjectScope, type SqlewProjectInput
+} from '../utils/project-scope-resolver.js';
+
+/** Tools whose actions operate on a specific project (need a bound project). */
+const PROJECT_SCOPED_TOOLS = new Set(['decision', 'constraint', 'suggest', 'queue']);
+
+/** Actions that never touch a project (documentation), allowed even when unbound. */
+const PROJECT_AGNOSTIC_ACTIONS = new Set(['help', 'example', 'use_case']);
+
+/** Per-tool write actions (mutate data) — drive create-on-missing / collision checks. */
+const WRITE_ACTIONS: Record<string, Set<string>> = {
+  decision: new Set([
+    'set', 'quick_set', 'set_batch', 'set_from_template', 'set_from_policy',
+    'create_template', 'create_policy', 'hard_delete', 'add_decision_context',
+  ]),
+  constraint: new Set(['add', 'activate', 'activate_by_tag', 'deactivate']),
+  queue: new Set(['clear', 'remove']),
+};
+
+function isWriteAction(tool: string, action: string): boolean {
+  return WRITE_ACTIONS[tool]?.has(action) ?? false;
+}
 
 /**
  * LocalBackend implementation
@@ -53,6 +82,61 @@ export class LocalBackend implements ToolBackend {
   ): Promise<TResponse> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const p = params as any;
+
+    // Extract & strip the reserved per-call project scope before dispatch, so
+    // it never reaches action validators (validateActionParams rejects unknown
+    // keys) and is resolved here at the single tool entry point instead.
+    const projectInput: SqlewProjectInput | undefined = p._sqlew_project;
+    if (projectInput !== undefined) {
+      delete p._sqlew_project;
+    }
+
+    const needsProject =
+      PROJECT_SCOPED_TOOLS.has(tool) && !PROJECT_AGNOSTIC_ACTIONS.has(action);
+
+    // Per-call project targeting: resolve and run the dispatch inside a
+    // request-scoped ProjectContext. AsyncLocalStorage propagates the scope
+    // across awaits, so every getProjectContext() call (including deep helpers
+    // and transaction callbacks) observes the target project — concurrency-safe.
+    if (projectInput && needsProject) {
+      const metadata = await resolveProjectScope(projectInput, {
+        forWrite: isWriteAction(tool, action),
+      });
+      const scoped = ProjectContext.createScoped(metadata);
+      return await runWithProjectScope(scoped, () =>
+        this.dispatch<TResponse>(tool, action, p)
+      );
+    }
+
+    // Fail-closed when the server is unbound (ambiguous desktop cwd) and the
+    // caller did not specify a project. help/example/use_case and the `project`
+    // tool stay usable so the agent can recover.
+    if (needsProject && getProjectContext().isUnbound()) {
+      throw new Error(
+        JSON.stringify({
+          error: 'SQLEW_PROJECT_REQUIRED',
+          message:
+            'sqlew has no bound project (the MCP server was launched from an ambiguous ' +
+            'directory). Pass _sqlew_project.root or .name on this call, or call the ' +
+            '"project" tool (action: resolve) first to obtain a ref.',
+          reason: getProjectContext().getUnboundReason() || undefined,
+        })
+      );
+    }
+
+    return await this.dispatch<TResponse>(tool, action, p);
+  }
+
+  /**
+   * Dispatch a validated tool/action to its handler. Runs inside the active
+   * ProjectContext scope (singleton or request-scoped) when called from execute().
+   */
+  private async dispatch<TResponse = unknown>(
+    tool: string,
+    action: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    p: any
+  ): Promise<TResponse> {
     let result: unknown;
 
     switch (tool) {
@@ -61,6 +145,9 @@ export class LocalBackend implements ToolBackend {
         break;
       case 'constraint':
         result = await this.executeConstraint(action, p);
+        break;
+      case 'project':
+        result = await this.executeProject(action, p);
         break;
       case 'help':
         result = await this.executeHelp(action, p);
@@ -384,11 +471,33 @@ export class LocalBackend implements ToolBackend {
    * Priority: ProjectContext.project_root_path > process.cwd()
    */
   private getProjectRoot(): string {
-    const ctx = ProjectContext.getInstance();
+    // Use the active context (request-scoped when _sqlew_project is supplied,
+    // singleton otherwise) so queue file paths follow the targeted project.
+    const ctx = getProjectContext();
     if (ctx.isInitialized()) {
       return ctx.getProjectMetadata().project_root_path || process.cwd();
     }
     return process.cwd();
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private async executeProject(action: string, params: any): Promise<unknown> {
+    switch (action) {
+      case 'current':
+        return projectCurrent();
+      case 'resolve':
+        return await projectResolve(params);
+      case 'list':
+        return await projectList();
+      case 'validate':
+        return await projectValidate(params);
+      case 'help':
+        return await projectHelp();
+      case 'example':
+        return await projectExample();
+      default:
+        throw new Error(`Unknown project action: ${action}`);
+    }
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/help-data/_schema.toml
+++ b/src/help-data/_schema.toml
@@ -12,7 +12,7 @@ parameter_naming = "snake_case"
 
 [tools]
 # List of available tools (for quick reference)
-available = ["decision", "constraint", "suggest", "help", "example", "use_case"]
+available = ["decision", "constraint", "project", "suggest", "help", "example", "use_case"]
 
 [complexity_levels]
 # Use case complexity definitions

--- a/src/help-data/project.toml
+++ b/src/help-data/project.toml
@@ -1,0 +1,191 @@
+# Project Tool - Per-call Project Resolution
+# Target a specific project for desktop AI agents and multi-project setups.
+
+[tool]
+name = "project"
+description = "Project resolution for tool-call-level project targeting. Desktop AI agents (Claude Desktop, Hermes Desktop) launch the MCP server from a fixed cwd, so the active project cannot be inferred. Resolve a project by root path or name to obtain a stable ref, then pass _sqlew_project: { ref } on decision/constraint/suggest/queue calls."
+
+# =============================================================================
+# ACTIONS
+# =============================================================================
+
+[[actions]]
+name = "current"
+description = "Show the active project for this session/call, or an unbound status when the server was launched from an ambiguous directory"
+
+  [[actions.params]]
+  name = "action"
+  type = "string"
+  required = true
+  description = "Must be \"current\""
+
+  [[actions.examples]]
+  title = "Show current project"
+  code = '''
+{
+  "action": "current"
+}
+'''
+  explanation = "Returns the bound project (id, name, root, ref) or { bound: false } with a hint when unbound"
+
+# -----------------------------------------------------------------------------
+
+[[actions]]
+name = "resolve"
+description = "Resolve (and optionally register) a project by root path, name, or ref. Returns a stable ref to reuse on subsequent calls."
+
+  [[actions.params]]
+  name = "action"
+  type = "string"
+  required = true
+  description = "Must be \"resolve\""
+
+  [[actions.params]]
+  name = "root"
+  type = "string"
+  required = false
+  description = "Absolute path to the project root. Name is derived from config.toml/git/dir; creates the project if missing."
+
+  [[actions.params]]
+  name = "name"
+  type = "string"
+  required = false
+  description = "Project name registered in m_projects. Looks up existing; creation requires allow_create."
+
+  [[actions.params]]
+  name = "ref"
+  type = "string"
+  required = false
+  description = "Existing stable ref (e.g. \"sqlew_proj_3\")"
+
+  [[actions.params]]
+  name = "allow_create"
+  type = "boolean"
+  required = false
+  description = "Allow creating a new project when resolving by name"
+
+  [[actions.examples]]
+  title = "Resolve by repo path"
+  code = '''
+{
+  "action": "resolve",
+  "root": "C:/Users/me/RustroverProjects/mcp-sqlew"
+}
+'''
+  explanation = "Returns { project: { id, name, root, ref }, usage: { _sqlew_project: { ref } } }. Pass the ref on later decision/constraint calls."
+
+# -----------------------------------------------------------------------------
+
+[[actions]]
+name = "list"
+description = "List all registered projects with their refs"
+
+  [[actions.params]]
+  name = "action"
+  type = "string"
+  required = true
+  description = "Must be \"list\""
+
+  [[actions.examples]]
+  title = "List projects"
+  code = '''
+{
+  "action": "list"
+}
+'''
+  explanation = "Returns all m_projects rows (id, name, root, detection_source, ref) ordered by most recently active"
+
+# -----------------------------------------------------------------------------
+
+[[actions]]
+name = "validate"
+description = "Check whether a root/name/ref resolves cleanly, without creating anything (read-only probe)"
+
+  [[actions.params]]
+  name = "action"
+  type = "string"
+  required = true
+  description = "Must be \"validate\""
+
+  [[actions.params]]
+  name = "root"
+  type = "string"
+  required = false
+  description = "Absolute path to the project root to validate"
+
+  [[actions.params]]
+  name = "name"
+  type = "string"
+  required = false
+  description = "Project name to validate"
+
+  [[actions.params]]
+  name = "ref"
+  type = "string"
+  required = false
+  description = "Project ref to validate"
+
+  [[actions.examples]]
+  title = "Validate a name"
+  code = '''
+{
+  "action": "validate",
+  "name": "mcp-sqlew"
+}
+'''
+  explanation = "Returns { ok: true, project } when registered, or { ok: false, error, message } (e.g. SQLEW_PROJECT_NOT_FOUND / SQLEW_PROJECT_NAME_COLLISION)"
+
+# -----------------------------------------------------------------------------
+
+[[actions]]
+name = "help"
+description = "Get project tool documentation"
+
+  [[actions.params]]
+  name = "action"
+  type = "string"
+  required = true
+  description = "Must be \"help\""
+
+  [[actions.examples]]
+  title = "Get help"
+  code = '''
+{
+  "action": "help"
+}
+'''
+  explanation = "Display project tool documentation"
+
+# -----------------------------------------------------------------------------
+
+[[actions]]
+name = "example"
+description = "Get project tool usage examples"
+
+  [[actions.params]]
+  name = "action"
+  type = "string"
+  required = true
+  description = "Must be \"example\""
+
+  [[actions.examples]]
+  title = "Get examples"
+  code = '''
+{
+  "action": "example"
+}
+'''
+  explanation = "Display project tool usage examples"
+
+# =============================================================================
+# USE CASES
+# =============================================================================
+
+[[use_cases]]
+title = "Record a decision from Claude Desktop / Hermes Desktop"
+description = "The MCP server is launched from the user home folder, so no project is bound. Establish the project once, then target it explicitly."
+steps = [
+  "1. project.resolve { root: \"C:/path/to/repo\" } -> copy usage._sqlew_project.ref",
+  "2. decision.set { key, value, _sqlew_project: { ref } }",
+  "3. Reuse the same _sqlew_project.ref for further decision/constraint calls"
+]

--- a/src/help-loader.ts
+++ b/src/help-loader.ts
@@ -167,7 +167,7 @@ export class HelpSystemLoader {
 
     try {
       // Load tool files
-      const toolFiles = ['decision', 'constraint', 'suggest', 'help', 'example', 'use_case', 'queue'];
+      const toolFiles = ['decision', 'constraint', 'project', 'suggest', 'help', 'example', 'use_case', 'queue'];
       for (const toolName of toolFiles) {
         const filePath = path.join(this.helpDataDir, `${toolName}.toml`);
         if (fs.existsSync(filePath)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,11 @@ async function startMcpServer(): Promise<void> {
       safeConsoleError(`  Database: ${dbPath} (from ${source})`);
     }
 
-    safeConsoleError(`  Project: ${setupResult.projectContext.getProjectName()} (ID: ${setupResult.projectContext.getProjectId()}, source: ${setupResult.detectionSource})`);
+    if (setupResult.projectContext.isUnbound()) {
+      safeConsoleError(`  Project: <unbound> (${setupResult.projectContext.getUnboundReason() || 'ambiguous launch directory'}) - pass _sqlew_project or use the "project" tool`);
+    } else {
+      safeConsoleError(`  Project: ${setupResult.projectContext.getProjectName()} (ID: ${setupResult.projectContext.getProjectId()}, source: ${setupResult.detectionSource})`);
+    }
 
     // Detect parent process exit (stdin pipe closed)
     // StdioServerTransport only listens for 'data'/'error', not 'end'

--- a/src/server/setup.ts
+++ b/src/server/setup.ts
@@ -23,7 +23,7 @@ import { detectVCS, GitAdapter } from '../utils/vcs-adapter.js';
 import { startQueueWatcher } from '../watcher/queue-watcher.js';
 import { initDebugLogger, debugLog } from '../utils/debug-logger.js';
 import { ensureSqlewDirectory } from '../config/example-generator.js';
-import { determineProjectRoot } from '../utils/project-root.js';
+import { determineProjectRoot, isAmbiguousProjectRoot, wasProjectRootExplicit } from '../utils/project-root.js';
 import { ParsedArgs } from './arg-parser.js';
 import { initializeSqlewRules } from '../init-rules.js';
 import { loadGlobalConfig, getDefaultDbPath } from '../config/global-config.js';
@@ -314,6 +314,10 @@ export async function initializeServer(parsedArgs: ParsedArgs): Promise<SetupRes
     // Local/RDBMS mode: Detect project name with priority order
     const knex = getAdapter().getKnex();
 
+    // P0: stays true only when we deliberately leave the project unbound
+    // (ambiguous desktop launch) — see the pollution guard below.
+    let unbound = false;
+
     // Priority order: CLI --project-name > config.toml > git remote > directory name
     if (parsedArgs.projectName) {
       projectName = parsedArgs.projectName;
@@ -344,8 +348,24 @@ export async function initializeServer(parsedArgs: ParsedArgs): Promise<SetupRes
         debugLog('INFO', 'Project name from directory (no VCS)', { projectName });
       }
 
-      // Write to config.toml if not present AND not CLI override
-      if (!parsedArgs.projectName) {
+      // P0 pollution guard: when the name came purely from the directory AND the
+      // root came from the bare cwd fallback AND that cwd is ambiguous (user home
+      // / system dir — e.g. a desktop AI agent launch), do NOT auto-register a
+      // directory-name project or write config.toml. Leave the context unbound so
+      // project-scoped tools require an explicit _sqlew_project (fail-closed).
+      const explicitRoot = wasProjectRootExplicit({
+        cliDbPath: parsedArgs.dbPath,
+        cliConfigPath: parsedArgs.configPath,
+        configDbPath: fileConfig.database?.path,
+      });
+      if (detectionSource === 'directory' && !explicitRoot && isAmbiguousProjectRoot(finalProjectRoot)) {
+        unbound = true;
+        projectContext.markUnbound(`launched from ambiguous directory: ${finalProjectRoot}`);
+        debugLog('WARN', 'Project left unbound (ambiguous launch directory)', { finalProjectRoot });
+      }
+
+      // Write to config.toml if not present AND not CLI override (skip when unbound)
+      if (!unbound && !parsedArgs.projectName) {
         const configWritten = ensureProjectConfig(finalProjectRoot, projectName, {
           configPath: parsedArgs.configPath,
         });
@@ -360,22 +380,24 @@ export async function initializeServer(parsedArgs: ParsedArgs): Promise<SetupRes
       }
     }
 
-    // Initialize with database
-    await projectContext.ensureProject(knex, projectName, detectionSource, {
-      projectRootPath: finalProjectRoot,
-    });
+    // Initialize with database (skip when unbound — nothing to register)
+    if (!unbound) {
+      await projectContext.ensureProject(knex, projectName, detectionSource, {
+        projectRootPath: finalProjectRoot,
+      });
 
-    debugLog('INFO', 'ProjectContext initialized', {
-      projectId: projectContext.getProjectId(),
-      projectName: projectContext.getProjectName(),
-    });
+      debugLog('INFO', 'ProjectContext initialized', {
+        projectId: projectContext.getProjectId(),
+        projectName: projectContext.getProjectName(),
+      });
+    }
   }
 
-  // Log successful initialization
+  // Log successful initialization (unbound contexts have no project to report)
   debugLog('INFO', 'MCP Shared Context Server initialized', {
     dbPath,
-    projectId: projectContext.getProjectId(),
-    projectName: projectContext.getProjectName(),
+    projectId: projectContext.isUnbound() ? null : projectContext.getProjectId(),
+    projectName: projectContext.isUnbound() ? '<unbound>' : projectContext.getProjectName(),
     debugLogLevel: debugLogLevel
   });
 

--- a/src/server/tool-schemas.ts
+++ b/src/server/tool-schemas.ts
@@ -15,6 +15,20 @@
 import { z } from 'zod';
 
 // ---------------------------------------------------------------------------
+// Shared: per-call project scope (desktop AI agents / multi-project)
+// Reserved parameter `_sqlew_project` targets a specific project for this call,
+// overriding the startup-detected project. Resolved by root path, name, or ref.
+// ---------------------------------------------------------------------------
+export const projectContextSchema = z.object({
+  _sqlew_project: z.object({
+    root: z.string().describe('Absolute path to the project root (repo directory)').optional(),
+    name: z.string().describe('Project name registered in m_projects').optional(),
+    ref: z.string().describe('Stable project ref from the "project" tool (e.g. "sqlew_proj_3")').optional(),
+    allow_create: z.boolean().describe('Allow creating a new project when resolving by name').optional(),
+  }).describe('Per-call project target (overrides startup detection). Use the "project" tool to obtain a ref.').optional(),
+});
+
+// ---------------------------------------------------------------------------
 // decision: action enum + passthrough (additionalProperties: true)
 // ---------------------------------------------------------------------------
 export const decisionSchema = z.object({
@@ -26,7 +40,7 @@ export const decisionSchema = z.object({
     'create_policy', 'list_policies', 'set_from_policy',
     'help', 'example', 'use_case',
   ]).describe('Action'),
-}).passthrough();
+}).merge(projectContextSchema).passthrough();
 
 // ---------------------------------------------------------------------------
 // constraint: action enum + passthrough (additionalProperties: true)
@@ -36,7 +50,7 @@ export const constraintSchema = z.object({
     'add', 'get', 'deactivate', 'suggest_pending',
     'help', 'example', 'use_case',
   ]).describe('Action'),
-}).passthrough();
+}).merge(projectContextSchema).passthrough();
 
 // ---------------------------------------------------------------------------
 // help: all params explicitly defined (additionalProperties: false by default)
@@ -101,7 +115,7 @@ export const suggestSchema = z.object({
   priority: z.number().describe('Priority level (optional)').optional(),
   limit: z.number().describe('Max suggestions (default: 5)').optional(),
   min_score: z.number().describe('Minimum relevance score (default: 30)').optional(),
-}).strict();
+}).merge(projectContextSchema).strict();
 
 // ---------------------------------------------------------------------------
 // queue: strict (additionalProperties: false)
@@ -111,6 +125,19 @@ export const queueSchema = z.object({
     'list', 'clear', 'remove', 'help', 'example',
   ]).describe('Queue action to perform'),
   index: z.number().describe('Item index for remove action (0-based)').optional(),
+}).merge(projectContextSchema).strict();
+
+// ---------------------------------------------------------------------------
+// project: per-call project resolution for desktop AI agents (strict)
+// ---------------------------------------------------------------------------
+export const projectSchema = z.object({
+  action: z.enum([
+    'current', 'resolve', 'list', 'validate', 'help', 'example',
+  ]).describe('Project action to perform'),
+  root: z.string().describe('Absolute path to the project root (for resolve, validate)').optional(),
+  name: z.string().describe('Project name (for resolve, validate)').optional(),
+  ref: z.string().describe('Stable project ref, e.g. "sqlew_proj_3" (for resolve, validate)').optional(),
+  allow_create: z.boolean().describe('Allow creating a new project when resolving by name').optional(),
 }).strict();
 
 // ---------------------------------------------------------------------------
@@ -121,6 +148,7 @@ export const queueSchema = z.object({
 export const TOOL_SCHEMAS: Record<string, z.ZodType> = {
   decision: decisionSchema,
   constraint: constraintSchema,
+  project: projectSchema,
   help: helpSchema,
   example: exampleSchema,
   use_case: useCaseSchema,
@@ -132,6 +160,15 @@ export const TOOL_SCHEMAS: Record<string, z.ZodType> = {
 export const TOOL_DESCRIPTIONS: Record<string, string> = {
   decision: 'Context Management - Store decisions with versioning and metadata. Use action: "help" for documentation.',
   constraint: 'Architectural Rules - Define and manage project constraints with priorities. Use action: "help" for documentation.',
+  project: `Project Resolution - Target a specific project per tool call (desktop AI agents / multi-project).
+
+Actions:
+- current: Show the active project (or unbound status)
+- resolve: Resolve/register a project by root path or name; returns a stable ref
+- list: List all registered projects
+- validate: Check whether a root/name/ref resolves cleanly (read-only)
+
+Desktop flow: call project.resolve { root } once, then pass _sqlew_project: { ref } on subsequent decision/constraint calls. Use action: "help" for documentation.`,
   help: `**REQUIRED PARAMETER**: action (must be specified in ALL calls)
 
 Help System - Query action documentation, parameters, and workflow guidance

--- a/src/tests/database/multi-project/project-scope.test.ts
+++ b/src/tests/database/multi-project/project-scope.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Desktop AI agent project resolution tests (v5.4)
+ *
+ * Covers:
+ * - resolveProjectScope: root (create), name (find / not-found), ref, collision
+ * - AsyncLocalStorage request-scope isolation (concurrency-safe project switch)
+ * - P0 unbound guard: fail-closed writes, help allowed, recovery via _sqlew_project
+ * - Per-call project targeting end-to-end through LocalBackend.execute
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { initializeDatabase, closeDatabase, getAdapter } from '../../../database.js';
+import type { DatabaseAdapter } from '../../../adapters/types.js';
+import {
+  ProjectContext,
+  getProjectContext,
+  runWithProjectScope,
+} from '../../../utils/project-context.js';
+import {
+  resolveProjectScope,
+  makeProjectRef,
+} from '../../../utils/project-scope-resolver.js';
+import { LocalBackend } from '../../../backend/local-backend.js';
+
+let testDb: DatabaseAdapter;
+let tempDir: string;
+let tempDbPath: string;
+
+/** Parse a JSON-encoded sqlew error thrown as an Error message. */
+function parseError(error: unknown): { error?: string; message?: string } {
+  const msg = error instanceof Error ? error.message : String(error);
+  try {
+    return JSON.parse(msg);
+  } catch {
+    return { message: msg };
+  }
+}
+
+beforeEach(async () => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sqlew-scope-'));
+  tempDbPath = path.join(tempDir, 'test.db');
+  testDb = await initializeDatabase({ connection: { filename: tempDbPath } });
+});
+
+afterEach(async () => {
+  ProjectContext.reset();
+  await closeDatabase();
+  if (tempDir && fs.existsSync(tempDir)) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+describe('resolveProjectScope', () => {
+  it('creates a project from a root path on write', async () => {
+    const repo = fs.mkdtempSync(path.join(tempDir, 'repo-'));
+    const meta = await resolveProjectScope({ root: repo }, { forWrite: true });
+    assert.ok(meta.id > 0);
+    assert.strictEqual(meta.name, path.basename(repo));
+    assert.ok(meta.project_root_path);
+  });
+
+  it('finds an existing project by name', async () => {
+    const repo = fs.mkdtempSync(path.join(tempDir, 'repo-'));
+    const created = await resolveProjectScope({ root: repo }, { forWrite: true });
+    const found = await resolveProjectScope({ name: created.name }, { forWrite: false });
+    assert.strictEqual(found.id, created.id);
+  });
+
+  it('errors on read when a name does not exist', async () => {
+    await assert.rejects(
+      () => resolveProjectScope({ name: 'does-not-exist' }, { forWrite: false }),
+      (err: unknown) => parseError(err).error === 'SQLEW_PROJECT_NOT_FOUND'
+    );
+  });
+
+  it('resolves by ref', async () => {
+    const repo = fs.mkdtempSync(path.join(tempDir, 'repo-'));
+    const created = await resolveProjectScope({ root: repo }, { forWrite: true });
+    const byRef = await resolveProjectScope(
+      { ref: makeProjectRef(created.id) },
+      { forWrite: false }
+    );
+    assert.strictEqual(byRef.id, created.id);
+  });
+
+  it('rejects a name collision (same name, different root) on write', async () => {
+    const knex = getAdapter().getKnex();
+    const now = Math.floor(Date.now() / 1000);
+    // Pre-register a project named "myproj" rooted elsewhere.
+    await knex('m_projects').insert({
+      name: 'myproj',
+      display_name: 'myproj',
+      detection_source: 'config',
+      project_root_path: '/somewhere/else/myproj',
+      created_ts: now,
+      last_active_ts: now,
+      metadata: null,
+    });
+    // A different directory whose basename is also "myproj".
+    const repo = path.join(tempDir, 'myproj');
+    fs.mkdirSync(repo);
+
+    await assert.rejects(
+      () => resolveProjectScope({ root: repo }, { forWrite: true }),
+      (err: unknown) => parseError(err).error === 'SQLEW_PROJECT_NAME_COLLISION'
+    );
+  });
+});
+
+describe('AsyncLocalStorage request-scope isolation', () => {
+  it('keeps concurrent scopes from cross-contaminating', async () => {
+    const ctxA = ProjectContext.createScoped({
+      id: 101, name: 'alpha', detection_source: 'metadata',
+    });
+    const ctxB = ProjectContext.createScoped({
+      id: 202, name: 'beta', detection_source: 'metadata',
+    });
+
+    const [a, b] = await Promise.all([
+      runWithProjectScope(ctxA, async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        return getProjectContext().getProjectId();
+      }),
+      runWithProjectScope(ctxB, async () => {
+        return getProjectContext().getProjectId();
+      }),
+    ]);
+
+    assert.strictEqual(a, 101);
+    assert.strictEqual(b, 202);
+  });
+
+  it('falls back to the singleton when no scope is active', async () => {
+    const knex = getAdapter().getKnex();
+    await ProjectContext.getInstance().ensureProject(knex, 'singleton-proj', 'config');
+    assert.strictEqual(getProjectContext().getProjectName(), 'singleton-proj');
+  });
+});
+
+describe('P0 unbound guard (LocalBackend.execute)', () => {
+  let backend: LocalBackend;
+
+  beforeEach(() => {
+    backend = new LocalBackend();
+    ProjectContext.getInstance().markUnbound('test: ambiguous launch directory');
+  });
+
+  it('fails closed on a project-scoped write', async () => {
+    await assert.rejects(
+      () => backend.execute('decision', 'set', { key: 'k', value: 'v' }),
+      (err: unknown) => parseError(err).error === 'SQLEW_PROJECT_REQUIRED'
+    );
+  });
+
+  it('allows help even when unbound', async () => {
+    const result = await backend.execute('decision', 'help', {});
+    assert.ok(result, 'help should return content while unbound');
+  });
+
+  it('allows the project tool even when unbound', async () => {
+    const result = (await backend.execute('project', 'current', {})) as { bound: boolean };
+    assert.strictEqual(result.bound, false);
+  });
+
+  it('recovers with an explicit _sqlew_project', async () => {
+    const repo = fs.mkdtempSync(path.join(tempDir, 'repo-'));
+    const result = (await backend.execute('decision', 'set', {
+      key: 'auth/method',
+      value: 'JWT',
+      _sqlew_project: { root: repo },
+    })) as { success?: boolean };
+    assert.ok(result, 'scoped write should succeed');
+
+    // The decision must be readable from the same targeted project.
+    const listed = (await backend.execute('decision', 'list', {
+      _sqlew_project: { root: repo },
+    })) as { decisions: Array<{ value: string }>; count: number };
+    assert.strictEqual(listed.count, 1);
+    assert.strictEqual(listed.decisions[0].value, 'JWT');
+  });
+});
+
+describe('project tool', () => {
+  it('resolve returns a reusable ref and usage hint', async () => {
+    const backend = new LocalBackend();
+    const repo = fs.mkdtempSync(path.join(tempDir, 'repo-'));
+    const result = (await backend.execute('project', 'resolve', { root: repo })) as {
+      project: { id: number; ref: string };
+      usage: { _sqlew_project: { ref: string } };
+    };
+    assert.ok(result.project.id > 0);
+    assert.match(result.project.ref, /^sqlew_proj_\d+$/);
+    assert.strictEqual(result.usage._sqlew_project.ref, result.project.ref);
+  });
+
+  it('list returns registered projects', async () => {
+    const backend = new LocalBackend();
+    const repo = fs.mkdtempSync(path.join(tempDir, 'repo-'));
+    await backend.execute('project', 'resolve', { root: repo });
+    const listed = (await backend.execute('project', 'list', {})) as { count: number };
+    assert.ok(listed.count >= 1);
+  });
+
+  it('validate reports ok/false without creating', async () => {
+    const backend = new LocalBackend();
+    const ok = (await backend.execute('project', 'validate', { name: 'never-registered' })) as {
+      ok: boolean; error?: string;
+    };
+    assert.strictEqual(ok.ok, false);
+    assert.strictEqual(ok.error, 'SQLEW_PROJECT_NOT_FOUND');
+  });
+
+  it('help loads from project.toml (guards the loader tool list)', async () => {
+    const backend = new LocalBackend();
+    const help = (await backend.execute('project', 'help', {})) as { tool?: string };
+    assert.strictEqual(help.tool, 'project');
+  });
+});
+
+describe('Per-call project targeting (bound singleton)', () => {
+  it('routes a write to the _sqlew_project, not the singleton project', async () => {
+    const knex = getAdapter().getKnex();
+    await ProjectContext.getInstance().ensureProject(knex, 'home-proj', 'config');
+
+    const backend = new LocalBackend();
+    const repo = fs.mkdtempSync(path.join(tempDir, 'repo-'));
+
+    // Write targeting a different project via root.
+    await backend.execute('decision', 'set', {
+      key: 'db/engine',
+      value: 'PostgreSQL',
+      _sqlew_project: { root: repo },
+    });
+
+    // Singleton project should have no decisions.
+    const home = (await backend.execute('decision', 'list', {})) as { count: number };
+    assert.strictEqual(home.count, 0);
+
+    // Targeted project should have exactly one.
+    const targeted = (await backend.execute('decision', 'list', {
+      _sqlew_project: { root: repo },
+    })) as { count: number; decisions: Array<{ value: string }> };
+    assert.strictEqual(targeted.count, 1);
+    assert.strictEqual(targeted.decisions[0].value, 'PostgreSQL');
+  });
+});

--- a/src/tools/project/actions/current.ts
+++ b/src/tools/project/actions/current.ts
@@ -1,0 +1,49 @@
+/**
+ * project.current - Report the active project for this MCP session/call.
+ *
+ * Reflects the request-scoped project when invoked with _sqlew_project, the
+ * startup-bound project otherwise, or an unbound status when the server was
+ * launched from an ambiguous cwd (desktop AI agents).
+ */
+
+import { getProjectContext } from '../../../utils/project-context.js';
+import { makeProjectRef } from '../../../utils/project-scope-resolver.js';
+import type { ProjectSummary } from '../types.js';
+
+export interface ProjectCurrentResponse {
+  bound: boolean;
+  project?: ProjectSummary;
+  reason?: string;
+  hint?: string;
+}
+
+export function projectCurrent(): ProjectCurrentResponse {
+  const ctx = getProjectContext();
+
+  if (ctx.isUnbound()) {
+    return {
+      bound: false,
+      reason: ctx.getUnboundReason() || 'No project resolvable from the launch directory.',
+      hint:
+        'Pass _sqlew_project.root or .name on tool calls, or call project.resolve ' +
+        'to register a project and reuse the returned ref.',
+    };
+  }
+
+  if (!ctx.isInitialized()) {
+    return { bound: false, reason: 'ProjectContext is not initialized.' };
+  }
+
+  const meta = ctx.getProjectMetadata();
+  return {
+    bound: true,
+    project: {
+      id: meta.id,
+      name: meta.name,
+      display_name: meta.display_name,
+      root: meta.project_root_path,
+      detection_source: meta.detection_source,
+      ref: makeProjectRef(meta.id),
+    },
+  };
+}

--- a/src/tools/project/actions/list.ts
+++ b/src/tools/project/actions/list.ts
@@ -1,0 +1,42 @@
+/**
+ * project.list - List all registered projects in m_projects.
+ *
+ * Helps a desktop agent discover known projects and their refs without prior
+ * knowledge of the database contents.
+ */
+
+import { getAdapter } from '../../../database.js';
+import { makeProjectRef } from '../../../utils/project-scope-resolver.js';
+import type { ProjectSummary } from '../types.js';
+
+export interface ProjectListResponse {
+  count: number;
+  projects: ProjectSummary[];
+}
+
+interface ProjectListRow {
+  id: number;
+  name: string;
+  display_name: string | null;
+  detection_source: string;
+  project_root_path: string | null;
+}
+
+export async function projectList(): Promise<ProjectListResponse> {
+  const knex = getAdapter().getKnex();
+  const rows = await knex('m_projects')
+    .select('id', 'name', 'display_name', 'detection_source', 'project_root_path')
+    .orderBy('last_active_ts', 'desc') as ProjectListRow[];
+
+  return {
+    count: rows.length,
+    projects: rows.map((r) => ({
+      id: r.id,
+      name: r.name,
+      display_name: r.display_name || undefined,
+      root: r.project_root_path || undefined,
+      detection_source: r.detection_source,
+      ref: makeProjectRef(r.id),
+    })),
+  };
+}

--- a/src/tools/project/actions/resolve.ts
+++ b/src/tools/project/actions/resolve.ts
@@ -1,0 +1,60 @@
+/**
+ * project.resolve - Resolve (and optionally register) a project, returning a
+ * stable ref for the agent to attach to subsequent decision/constraint calls
+ * via _sqlew_project.ref.
+ *
+ * Typical desktop flow:
+ *   1. project.resolve { root: "C:/.../mcp-sqlew" }  -> { project, usage }
+ *   2. decision.set { ..., _sqlew_project: { ref } }
+ */
+
+import {
+  resolveProjectScope,
+  makeProjectRef,
+} from '../../../utils/project-scope-resolver.js';
+import type { ProjectSummary, ProjectToolParams } from '../types.js';
+
+export interface ProjectResolveResponse {
+  project: ProjectSummary;
+  usage: { _sqlew_project: { ref: string } };
+}
+
+export async function projectResolve(
+  params: ProjectToolParams
+): Promise<ProjectResolveResponse> {
+  if (!params.root && !params.name && !params.ref) {
+    throw new Error(
+      JSON.stringify({
+        error: 'SQLEW_PROJECT_REQUIRED',
+        message: 'project.resolve requires one of: root, name, ref.',
+      })
+    );
+  }
+
+  // root resolves deterministically and may register a new project; name-only
+  // creation requires explicit allow_create to avoid accidental duplicates.
+  const forWrite = params.allow_create ?? Boolean(params.root);
+
+  const meta = await resolveProjectScope(
+    {
+      root: params.root,
+      name: params.name,
+      ref: params.ref,
+      allow_create: params.allow_create,
+    },
+    { forWrite }
+  );
+
+  const ref = makeProjectRef(meta.id);
+  return {
+    project: {
+      id: meta.id,
+      name: meta.name,
+      display_name: meta.display_name,
+      root: meta.project_root_path,
+      detection_source: meta.detection_source,
+      ref,
+    },
+    usage: { _sqlew_project: { ref } },
+  };
+}

--- a/src/tools/project/actions/validate.ts
+++ b/src/tools/project/actions/validate.ts
@@ -1,0 +1,59 @@
+/**
+ * project.validate - Check whether a root/name/ref resolves cleanly, WITHOUT
+ * creating anything. Returns a structured ok/false result instead of throwing,
+ * so an agent can probe before committing writes.
+ */
+
+import {
+  resolveProjectScope,
+  makeProjectRef,
+} from '../../../utils/project-scope-resolver.js';
+import type { ProjectSummary, ProjectToolParams } from '../types.js';
+
+export interface ProjectValidateResponse {
+  ok: boolean;
+  project?: ProjectSummary;
+  error?: string;
+  message?: string;
+}
+
+export async function projectValidate(
+  params: ProjectToolParams
+): Promise<ProjectValidateResponse> {
+  if (!params.root && !params.name && !params.ref) {
+    return {
+      ok: false,
+      error: 'SQLEW_PROJECT_REQUIRED',
+      message: 'project.validate requires one of: root, name, ref.',
+    };
+  }
+
+  try {
+    // Read-only: never create. A brand-new (unregistered) repo path therefore
+    // reports ok:false with SQLEW_PROJECT_NOT_FOUND — use project.resolve to register.
+    const meta = await resolveProjectScope(
+      { root: params.root, name: params.name, ref: params.ref },
+      { forWrite: false }
+    );
+    return {
+      ok: true,
+      project: {
+        id: meta.id,
+        name: meta.name,
+        display_name: meta.display_name,
+        root: meta.project_root_path,
+        detection_source: meta.detection_source,
+        ref: makeProjectRef(meta.id),
+      },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    // resolver throws JSON-encoded { error, message }; surface it structurally.
+    try {
+      const parsed = JSON.parse(message);
+      return { ok: false, error: parsed.error, message: parsed.message };
+    } catch {
+      return { ok: false, error: 'SQLEW_PROJECT_VALIDATE_FAILED', message };
+    }
+  }
+}

--- a/src/tools/project/index.ts
+++ b/src/tools/project/index.ts
@@ -1,0 +1,55 @@
+/**
+ * `project` MCP tool - resolve and inspect projects for tool-call-level
+ * project targeting (desktop AI agents).
+ *
+ * Actions: current | resolve | list | validate | help | example
+ */
+
+import { getHelpLoader } from '../../help-loader.js';
+import { trackAndReturnHelp } from '../../utils/help-tracking.js';
+import { projectCurrent } from './actions/current.js';
+import { projectResolve } from './actions/resolve.js';
+import { projectList } from './actions/list.js';
+import { projectValidate } from './actions/validate.js';
+
+export { projectCurrent, projectResolve, projectList, projectValidate };
+
+/** Build project tool documentation from help-data/project.toml. */
+export async function projectHelp(): Promise<unknown> {
+  const loader = await getHelpLoader();
+  const tool = loader.getTool('project');
+  if (!tool) {
+    return { error: 'Project help not found' };
+  }
+  const helpContent = {
+    tool: tool.name,
+    description: tool.description,
+    actions: tool.actions.map((a) => ({
+      name: a.name,
+      description: a.description,
+      params: a.params,
+    })),
+  };
+  trackAndReturnHelp('project', 'help', JSON.stringify(helpContent));
+  return helpContent;
+}
+
+/** Build project tool examples from help-data/project.toml. */
+export async function projectExample(): Promise<unknown> {
+  const loader = await getHelpLoader();
+  const tool = loader.getTool('project');
+  if (!tool) {
+    return { error: 'Project examples not found' };
+  }
+  const exampleContent = {
+    tool: tool.name,
+    examples: tool.actions.flatMap((a) =>
+      a.examples.map((ex) => ({
+        action: a.name,
+        ...ex,
+      }))
+    ),
+  };
+  trackAndReturnHelp('project', 'example', JSON.stringify(exampleContent));
+  return exampleContent;
+}

--- a/src/tools/project/types.ts
+++ b/src/tools/project/types.ts
@@ -1,0 +1,32 @@
+/**
+ * Type definitions for the `project` MCP tool.
+ */
+
+export type ProjectAction =
+  | 'current'
+  | 'resolve'
+  | 'list'
+  | 'validate'
+  | 'help'
+  | 'example';
+
+export interface ProjectToolParams {
+  action: ProjectAction;
+  /** Absolute path to the project root (for resolve/validate). */
+  root?: string;
+  /** Project name (for resolve/validate). */
+  name?: string;
+  /** Stable ref, e.g. "sqlew_proj_3" (for resolve/validate). */
+  ref?: string;
+  /** Allow creating a new project when resolving by name. */
+  allow_create?: boolean;
+}
+
+export interface ProjectSummary {
+  id: number;
+  name: string;
+  display_name?: string;
+  root?: string;
+  detection_source: string;
+  ref: string;
+}

--- a/src/utils/project-context.ts
+++ b/src/utils/project-context.ts
@@ -8,6 +8,7 @@
  * - #23, #24 (CRITICAL): Config.toml as source of truth, auto-write on first run
  */
 
+import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Knex } from 'knex';
 
 export interface ProjectMetadata {
@@ -35,9 +36,39 @@ export class ProjectContext {
   private initialized = false;
 
   /**
+   * Unbound state (desktop AI agents launched from an ambiguous cwd).
+   *
+   * When the MCP server is started from an ambiguous location (user home,
+   * system directory) without any explicit project signal, the server stays
+   * up but refuses to auto-register a directory-name project. Project-scoped
+   * write/read actions then fail-closed with SQLEW_PROJECT_REQUIRED unless the
+   * caller passes a per-request scope (_sqlew_project). help/example/use_case
+   * and the `project` tool remain usable so the agent can recover.
+   */
+  private unbound = false;
+  private unboundReason: string | null = null;
+
+  /**
    * Private constructor enforces singleton pattern
    */
   private constructor() {}
+
+  /**
+   * Create a request-scoped (non-singleton) ProjectContext.
+   *
+   * Used together with runWithProjectScope() to override the active project
+   * for the duration of a single MCP tool call (per-call project targeting).
+   * The returned instance is fully initialized and independent of the
+   * singleton, so concurrent calls never cross-contaminate.
+   *
+   * @param metadata - Resolved project metadata to bind to this scope
+   */
+  public static createScoped(metadata: ProjectMetadata): ProjectContext {
+    const ctx = new ProjectContext();
+    ctx.projectMetadata = metadata;
+    ctx.initialized = true;
+    return ctx;
+  }
 
   /**
    * Get singleton instance
@@ -57,6 +88,8 @@ export class ProjectContext {
     if (ProjectContext.instance) {
       ProjectContext.instance.projectMetadata = null;
       ProjectContext.instance.initialized = false;
+      ProjectContext.instance.unbound = false;
+      ProjectContext.instance.unboundReason = null;
     }
     ProjectContext.instance = null;
   }
@@ -216,6 +249,9 @@ export class ProjectContext {
    * Satisfies Constraint #44: Provide getProjectId() method
    */
   public getProjectId(): number {
+    if (this.unbound) {
+      throw new Error(this.unboundError());
+    }
     if (!this.initialized || !this.projectMetadata) {
       throw new Error(
         'ProjectContext not initialized. Call ensureProject() first during server startup.'
@@ -233,6 +269,9 @@ export class ProjectContext {
    * Satisfies Constraint #44: Provide getProjectName() method
    */
   public getProjectName(): string {
+    if (this.unbound) {
+      throw new Error(this.unboundError());
+    }
     if (!this.initialized || !this.projectMetadata) {
       throw new Error(
         'ProjectContext not initialized. Call ensureProject() first during server startup.'
@@ -263,6 +302,51 @@ export class ProjectContext {
    */
   public isInitialized(): boolean {
     return this.initialized && this.projectMetadata !== null;
+  }
+
+  /**
+   * Mark this context as unbound (ambiguous startup cwd, no explicit project).
+   *
+   * Clears any cached metadata. After this, getProjectId()/getProjectName()
+   * throw a SQLEW_PROJECT_REQUIRED error until a request-scoped context is
+   * supplied via runWithProjectScope().
+   *
+   * @param reason - Human-readable reason (e.g. the ambiguous cwd) for diagnostics
+   */
+  public markUnbound(reason: string): void {
+    this.unbound = true;
+    this.unboundReason = reason;
+    this.initialized = false;
+    this.projectMetadata = null;
+  }
+
+  /**
+   * Whether this context is unbound (no project resolvable at startup).
+   */
+  public isUnbound(): boolean {
+    return this.unbound;
+  }
+
+  /**
+   * Diagnostic reason for the unbound state, if any.
+   */
+  public getUnboundReason(): string | null {
+    return this.unboundReason;
+  }
+
+  /**
+   * Build the structured SQLEW_PROJECT_REQUIRED error message.
+   */
+  private unboundError(): string {
+    return JSON.stringify({
+      error: 'SQLEW_PROJECT_REQUIRED',
+      message:
+        'sqlew could not determine a project from the MCP server launch directory' +
+        (this.unboundReason ? ` (${this.unboundReason})` : '') +
+        '. Pass _sqlew_project.root (absolute repo path) or _sqlew_project.name on this call, ' +
+        'or call the "project" tool (action: resolve) first to obtain a ref. ' +
+        'Alternatively set SQLEW_PROJECT_ROOT in the MCP server env.',
+    });
   }
 
   /**
@@ -297,10 +381,41 @@ export class ProjectContext {
 }
 
 /**
- * Convenience function to get the singleton instance
+ * AsyncLocalStorage holding the request-scoped ProjectContext (if any).
  *
- * @returns ProjectContext singleton instance
+ * This is the mechanism that turns sqlew's process-level project detection
+ * into per-call project targeting WITHOUT touching the ~25 call sites that
+ * read getProjectContext().getProjectId(). The scope propagates across awaits,
+ * so transaction callbacks and deep internal helpers all observe it.
+ */
+const projectScopeStorage = new AsyncLocalStorage<ProjectContext>();
+
+/**
+ * Run `fn` with a request-scoped ProjectContext active.
+ *
+ * Any getProjectContext() call inside `fn` (including across awaits) returns
+ * `ctx` instead of the singleton. Concurrent calls each get their own scope,
+ * so projects never cross-contaminate.
+ *
+ * @param ctx - The scoped ProjectContext (see ProjectContext.createScoped)
+ * @param fn - The work to run within the scope
+ */
+export function runWithProjectScope<T>(
+  ctx: ProjectContext,
+  fn: () => Promise<T>
+): Promise<T> {
+  return projectScopeStorage.run(ctx, fn);
+}
+
+/**
+ * Convenience function to get the active ProjectContext.
+ *
+ * Returns the request-scoped context when one is active (set via
+ * runWithProjectScope), otherwise falls back to the process singleton.
+ * Signature is unchanged so existing call sites need no modification.
+ *
+ * @returns The active ProjectContext (scoped or singleton)
  */
 export function getProjectContext(): ProjectContext {
-  return ProjectContext.getInstance();
+  return projectScopeStorage.getStore() ?? ProjectContext.getInstance();
 }

--- a/src/utils/project-root.ts
+++ b/src/utils/project-root.ts
@@ -23,6 +23,7 @@
  */
 
 import * as path from 'path';
+import * as os from 'os';
 
 export interface ProjectRootOptions {
   /**
@@ -172,4 +173,71 @@ export function isSystemDirectory(dirPath: string): boolean {
   ];
 
   return systemDirs.some(sysDir => normalizedPath.includes(sysDir));
+}
+
+/**
+ * Whether the project root was determined from an explicit signal rather than
+ * the bare process.cwd() fallback.
+ *
+ * Mirrors the priority-0..4 checks in determineProjectRoot(): if any of the
+ * recognized environment variables or CLI/config path arguments are present
+ * (as absolute paths), the integrator clearly intended a specific project, so
+ * the launch is trusted and never treated as ambiguous.
+ *
+ * @param options - Same options passed to determineProjectRoot()
+ * @returns true if an explicit root signal was provided
+ */
+export function wasProjectRootExplicit(options: ProjectRootOptions = {}): boolean {
+  const envSignals = [
+    process.env.CLAUDE_PROJECT_DIR,
+    process.env.GROK_WORKSPACE_ROOT,
+    process.env.CODEX_CWD,
+    process.env.TERMINAL_CWD,
+    process.env.SQLEW_PROJECT_ROOT,
+  ];
+  if (envSignals.some(value => value && path.isAbsolute(value))) {
+    return true;
+  }
+  if (options.cliDbPath && path.isAbsolute(options.cliDbPath)) return true;
+  if (options.cliConfigPath && path.isAbsolute(options.cliConfigPath)) return true;
+  if (options.configDbPath && path.isAbsolute(options.configDbPath)) return true;
+  return false;
+}
+
+/**
+ * Whether a directory is too ambiguous to safely auto-register as a project.
+ *
+ * Desktop AI agents (Claude Desktop, Hermes Desktop, etc.) often spawn the MCP
+ * server with a fixed cwd such as the user home folder or a system directory.
+ * Auto-deriving a project name from those locations pollutes the shared DB
+ * (e.g. a "kitayama" project from C:\Users\kitayama). This guard is kept
+ * intentionally conservative so legitimate first-run CLI usage from a plain
+ * project folder is NOT affected:
+ *
+ * - Windows system directories (System32, Program Files, ...)
+ * - The user home directory itself
+ *
+ * Workspace-container detection (~/Projects, ~/Documents, ...) is deliberately
+ * left out for now to avoid false positives; it can be layered on later.
+ *
+ * @param root - Project root directory to evaluate
+ * @returns true if the directory is an ambiguous launch location
+ */
+export function isAmbiguousProjectRoot(root: string): boolean {
+  if (!root) {
+    return true;
+  }
+  if (isSystemDirectory(root)) {
+    return true;
+  }
+
+  const normalizedRoot = path.resolve(root).replace(/\\/g, '/').toLowerCase();
+  const home = path.resolve(os.homedir()).replace(/\\/g, '/').toLowerCase();
+
+  // The user home directory itself is ambiguous (the canonical desktop case).
+  if (normalizedRoot === home) {
+    return true;
+  }
+
+  return false;
 }

--- a/src/utils/project-scope-resolver.ts
+++ b/src/utils/project-scope-resolver.ts
@@ -1,0 +1,214 @@
+/**
+ * Project Scope Resolver
+ *
+ * Resolves a per-call project target (the reserved `_sqlew_project` tool
+ * parameter, and the `project` tool's root/name/ref inputs) into concrete
+ * project metadata backed by the m_projects table.
+ *
+ * This enables tool-call-level project targeting for desktop AI agents
+ * (Claude Desktop, Hermes Desktop, ...) whose MCP server cwd does not identify
+ * the active project. It generalizes the existing read-only `_reference_project`
+ * precedent (name-only lookup in list/search_layer) to also accept an absolute
+ * repo path and a stable ref, and to optionally create on write.
+ *
+ * Resolution order: ref > root > name.
+ *
+ * Backward compatibility: the m_projects schema is unchanged. Name remains the
+ * unique key, so a name that already exists with a *different* root is treated
+ * as a collision and rejected on writes (fail-closed) to avoid writing ADRs to
+ * the wrong project.
+ */
+
+import * as path from 'path';
+import { existsSync } from 'fs';
+import type { Knex } from 'knex';
+import { getAdapter } from '../database.js';
+import { detectProjectName } from './project-detector.js';
+import type { ProjectMetadata } from './project-context.js';
+
+/** Reserved per-call project scope (the `_sqlew_project` tool parameter). */
+export interface SqlewProjectInput {
+  /** Absolute path to the project root (repo directory). */
+  root?: string;
+  /** Project name as registered in m_projects. */
+  name?: string;
+  /** Stable ref returned by the `project` tool (e.g. "sqlew_proj_3"). */
+  ref?: string;
+  /** Allow creating a new project when resolving by name (writes only). */
+  allow_create?: boolean;
+}
+
+export interface ResolveOptions {
+  /** Whether the calling action mutates data (create-on-missing, collision check). */
+  forWrite: boolean;
+}
+
+const REF_PREFIX = 'sqlew_proj_';
+
+/** Build the stable ref string for a project id. */
+export function makeProjectRef(id: number): string {
+  return `${REF_PREFIX}${id}`;
+}
+
+/** Parse a ref string back into a numeric id, or null if malformed. */
+function parseRef(ref: string): number | null {
+  if (!ref.startsWith(REF_PREFIX)) {
+    return null;
+  }
+  const id = Number(ref.slice(REF_PREFIX.length));
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
+
+/** Throw a structured resolver error (JSON string, matching sqlew conventions). */
+function fail(code: string, message: string): never {
+  throw new Error(JSON.stringify({ error: code, message }));
+}
+
+interface ProjectRow {
+  id: number;
+  name: string;
+  display_name: string | null;
+  detection_source: string;
+  project_root_path: string | null;
+  metadata: string | null;
+}
+
+function rowToMetadata(row: ProjectRow): ProjectMetadata {
+  return {
+    id: row.id,
+    name: row.name,
+    display_name: row.display_name || undefined,
+    detection_source: row.detection_source as ProjectMetadata['detection_source'],
+    project_root_path: row.project_root_path || undefined,
+    metadata: row.metadata ? JSON.parse(row.metadata) : undefined,
+  };
+}
+
+/** Normalize a filesystem path for comparison (forward slashes, lowercase). */
+function normalizePath(p: string): string {
+  return path.resolve(p).replace(/\\/g, '/').toLowerCase();
+}
+
+/**
+ * Project names share ProjectContext's validation rule (alphanumeric, hyphen,
+ * underscore, <= 64 chars). Auto-deriving a name from a non-ASCII directory
+ * would otherwise insert an unusable row; fail with a clear, actionable error
+ * instead. (Slugification is intentionally out of scope for now.)
+ */
+function assertValidProjectName(name: string): void {
+  if (name.length > 64 || !/^[a-zA-Z0-9_-]+$/.test(name)) {
+    fail(
+      'SQLEW_PROJECT_NAME_INVALID',
+      `Cannot derive a valid project name ("${name}"). Set [project].name in ` +
+      `.sqlew/config.toml (alphanumeric, hyphen, underscore; max 64 chars) and retry.`
+    );
+  }
+}
+
+/**
+ * Resolve a per-call project scope into concrete project metadata.
+ *
+ * @param input - The `_sqlew_project` value (root / name / ref)
+ * @param opts - Whether the calling action is a write
+ * @returns Resolved project metadata (find-or-create per the rules above)
+ */
+export async function resolveProjectScope(
+  input: SqlewProjectInput,
+  opts: ResolveOptions
+): Promise<ProjectMetadata> {
+  const knex = getAdapter().getKnex();
+
+  // 1. ref: most specific, points at an exact m_projects row.
+  if (input.ref) {
+    const id = parseRef(input.ref);
+    if (id === null) {
+      fail('SQLEW_PROJECT_REF_INVALID', `Invalid _sqlew_project.ref: "${input.ref}".`);
+    }
+    const row = await knex('m_projects').where({ id }).first<ProjectRow>();
+    if (!row) {
+      fail('SQLEW_PROJECT_NOT_FOUND', `No project for ref "${input.ref}".`);
+    }
+    return rowToMetadata(row);
+  }
+
+  // 2. root: deterministic — derive name from config/git/dir, find-or-create.
+  if (input.root) {
+    const root = path.resolve(input.root).replace(/\\/g, '/');
+    if (!existsSync(root)) {
+      fail('SQLEW_PROJECT_ROOT_NOT_FOUND', `_sqlew_project.root does not exist: "${root}".`);
+    }
+    const detected = await detectProjectName(root);
+    return findOrCreate(knex, detected.name, root, detected.source, opts);
+  }
+
+  // 3. name: look up existing; create only on write + allow_create.
+  if (input.name) {
+    return findOrCreate(knex, input.name, undefined, 'metadata', {
+      forWrite: opts.forWrite && (input.allow_create ?? true),
+    });
+  }
+
+  fail(
+    'SQLEW_PROJECT_REQUIRED',
+    '_sqlew_project must specify one of: root, name, or ref.'
+  );
+}
+
+/**
+ * Find an existing project by name, or create it when permitted.
+ *
+ * Collision rule: if the name exists with a different recorded root, reject on
+ * write (avoid mis-targeting); allow on read (best-effort cross-project query).
+ */
+async function findOrCreate(
+  knex: Knex,
+  name: string,
+  root: string | undefined,
+  source: ProjectMetadata['detection_source'],
+  opts: ResolveOptions
+): Promise<ProjectMetadata> {
+  const existing = await knex('m_projects').where({ name }).first<ProjectRow>();
+
+  if (existing) {
+    if (
+      root &&
+      existing.project_root_path &&
+      normalizePath(existing.project_root_path) !== normalizePath(root)
+    ) {
+      if (opts.forWrite) {
+        fail(
+          'SQLEW_PROJECT_NAME_COLLISION',
+          `Project "${name}" already exists with a different root ` +
+          `("${existing.project_root_path}" vs "${root}"). Set a unique [project].name ` +
+          `in .sqlew/config.toml for this repo to avoid mixing ADRs.`
+        );
+      }
+      // read: fall through and use the existing row (best-effort)
+    }
+    return rowToMetadata(existing);
+  }
+
+  if (!opts.forWrite) {
+    fail('SQLEW_PROJECT_NOT_FOUND', `Project "${name}" not found.`);
+  }
+
+  assertValidProjectName(name);
+
+  const now = Math.floor(Date.now() / 1000);
+  await knex('m_projects').insert({
+    name,
+    display_name: name,
+    detection_source: source,
+    project_root_path: root ?? null,
+    created_ts: now,
+    last_active_ts: now,
+    metadata: null,
+  });
+
+  // Refetch by name (avoids cross-database .returning() inconsistencies).
+  const created = await knex('m_projects').where({ name }).first<ProjectRow>();
+  if (!created) {
+    fail('SQLEW_PROJECT_CREATE_FAILED', `Failed to create project "${name}".`);
+  }
+  return rowToMetadata(created);
+}


### PR DESCRIPTION
## Summary

- Desktop AI agents (Claude Desktop, Hermes Desktop) launch the MCP server from a fixed cwd (often the user home folder), so sqlew's startup-time project detection cannot identify the active project — every project collapses into one, or a bogus directory-name project pollutes the shared DB.
- This PR extends project resolution from **process-level** to **per-tool-call**, fully backward compatible and with no database migration.
- Adds a per-call `_sqlew_project` parameter, a new `project` tool, and a fail-closed pollution guard for ambiguous launch directories.

(No pre-existing ADRs matched the diff via `suggest by_context`; the decisions below are the design decisions made in this PR.)

## Architecture Decisions

### Decision: Per-call project targeting via AsyncLocalStorage chokepoint (minimal blast radius)

`getProjectContext()` is the single function every project-scoped read goes through (~25 call sites, many in deep helpers that never receive tool params). Threading a project id through all of them would be invasive and error-prone. Instead the request scope is set once and read transparently everywhere.

- `src/utils/project-context.ts`: add `AsyncLocalStorage`, `runWithProjectScope()`, `ProjectContext.createScoped()`; `getProjectContext()` now returns the scoped context when active, else the singleton (signature unchanged — call sites untouched). Concurrency-safe (scope propagates across awaits).
- `src/backend/local-backend.ts`: resolve `_sqlew_project` at the single tool entry point (`execute()`), strip it from params, and run the dispatch inside `runWithProjectScope`. Extracted the dispatch switch into `dispatch()`. `getProjectRoot()` now uses the active scope so queue paths follow the target project.

### Decision: Reserved `_sqlew_project` parameter (root / name / ref), generalizing `_reference_project`

Desktop agents know a repo path or can resolve a stable ref; both must be expressible per call. Underscore prefix avoids collision with ADR content.

- `src/utils/project-scope-resolver.ts` (new): resolve by ref > root > name; find-or-create in `m_projects`; deterministic name derivation from a root via the existing `detectProjectName` (config > git > dir).
- `src/server/tool-schemas.ts`: add shared `projectContextSchema`; merge into `decision`/`constraint` (passthrough) and the `.strict()` `suggest`/`queue` (required so strict does not reject it).

### Decision: Dedicated `project` MCP tool (current / resolve / list / validate)

Gives desktop agents an explicit "resolve once, reuse the ref" flow instead of guessing on every call.

- `src/tools/project/**` (new): actions + help/example.
- `src/backend/local-backend.ts`: `project` dispatch (bypasses the unbound guard — it is the recovery path).
- `src/help-data/project.toml` (new), `src/help-data/_schema.toml`: register the tool.
- `src/help-loader.ts`: fix the hardcoded tool-file list to include `project` (otherwise `project help`/`example` silently return "not found").

### Constraint: Ambiguous launch dirs fail closed (do not auto-register a project / write config)

Writing ADRs to the wrong project is worse than failing. When launched from the user home or a system directory with no explicit signal, the context is left **unbound**.

- `src/utils/project-root.ts`: `isAmbiguousProjectRoot()` (conservative: home / system dir only) and `wasProjectRootExplicit()`.
- `src/server/setup.ts`: skip `ensureProjectConfig()` and `ensureProject()` and call `markUnbound()` for ambiguous + non-explicit + directory-derived launches.
- `src/utils/project-context.ts`: `markUnbound()`/`isUnbound()`; `getProjectId()`/`getProjectName()` throw `SQLEW_PROJECT_REQUIRED` while unbound.
- `src/backend/local-backend.ts`: project-scoped tools fail closed when unbound and no `_sqlew_project`; `help`/`example`/`use_case`/`project` stay usable.
- `src/index.ts`: startup log reports `<unbound>` instead of throwing.

### Constraint: No schema change; same-name/different-root rejected on write

`m_projects.name` stays the unique key (no migration). A name that already exists with a different recorded root is a collision and is rejected on writes (`SQLEW_PROJECT_NAME_COLLISION`); reads are best-effort. The existing read-only `_reference_project` is untouched.

## Other Changes

- `package.json`, `package-lock.json`, `manifest.json`: bump version to `5.3.1`.
- `CHANGELOG.md`: 5.3.1 entry.
- `docs/SHARED_DATABASE.md`, `README.md`: document desktop project resolution, `_sqlew_project`, and the `project` tool.
- `src/tests/database/multi-project/project-scope.test.ts` (new): resolver (root/name/ref/collision), AsyncLocalStorage isolation, unbound guard + recovery, `project` tool.

## Backward Compatibility

- `_sqlew_project` omitted + any explicit signal (`CLAUDE_PROJECT_DIR`, `GROK_WORKSPACE_ROOT`, `CODEX_CWD`, `TERMINAL_CWD`, `SQLEW_PROJECT_ROOT`, `--db-path`, `--config-path`, config `database.path`) or a normal repo-cwd launch → behavior unchanged.
- No DB migration. `_reference_project` unchanged.

## Test Plan

- [x] `npm run build` (tsc clean)
- [x] `npm test` — 543 pass / 0 fail (16 new)
- [x] `semgrep --config=p/typescript` on new/changed files — 0 findings
- [x] Smoke: `project help` loads from `project.toml`
- [ ] Manual via MCP inspector: launch from home cwd → write fails closed; `project.resolve { root }` → reuse `ref` → write/read scoped correctly
