### PR TITLE
feat(session-context): multi-harness session context injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ CLAUDE.md
 
 # Cursor MCP tool descriptors (auto-generated)
 mcps/
+agent-tools/
 
 # Dependencies
 node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added
+
+**Session context injection (multi-harness, v5.4.0)**
+
+Proactively injects recent decisions and active constraints at session start so agents do not need to call `suggest` first.
+
+- **Snapshot file** — MCP server writes `.sqlew/session-context.json` (top 15 decisions + top 15 active constraints). Hooks read the file only; they never open the database.
+- **`[hooks]` config** — `session_context_budget` (default `500` tokens, `0` disables injection and snapshot writes). First config source wins; no deep merge between local and global.
+- **Delivery** — Claude Code: `SessionStart` (startup/clear). Hermes: first `pre_llm_call` combined with plan guidance. Codex: `SessionStart` or `UserPromptSubmit` fallback with session-id dedup.
+- **Dedup marker** — `~/.config/sqlew/session-cache/<project>.context.json` prevents double injection across SessionStart and on-prompt.
+
+### Documentation
+
+- **Harness Compatibility** — New [docs/HARNESS_COMPATIBILITY.md](docs/HARNESS_COMPATIBILITY.md) matrix: which features work on Claude Code, Codex, Grok Build, Hermes, and other harness (MCP server only) setups.
+
+### Limitations
+
+- **Grok Build** — Passive hooks ignore stdout; session context injection is not available in v5.4. Use skills or `/sqlew search` manually.
+
+---
+
 ## [5.3.2] - 2026-07-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -121,7 +121,9 @@ hermes plugins remove sqlew
 
 If you merged hooks manually before using the plugin, also remove `mcp_servers.sqlew` and sqlew `hooks:` entries from `~/.hermes/config.yaml`. Skills under `~/.hermes/skills/sqlew-*` are not removed automatically.
 
-#### Manual (MCP only)
+#### Other harness (MCP only)
+
+MCP server only — no sqlew-plugin hooks or skills (Cursor, Claude Desktop, custom clients, …). See [Harness Compatibility](docs/HARNESS_COMPATIBILITY.md#other-harness--what-is-this-column).
 
 Add to `.mcp.json` in your project root:
 
@@ -150,8 +152,24 @@ No special commands needed — just plan your work normally, and sqlew captures 
 - **Duplicate Detection** — Three-tier similarity scoring (0-100) prevents redundant decisions
 - **Constraint Tracking** — Architectural rules and principles as first-class entities
 - **Auto-Capture** — Hooks automatically record decisions from Plan Mode (Claude Code, Codex, Grok Build, and Hermes via sqlew-plugin)
+- **Session Context Injection** — Recent decisions and active constraints injected at session start (Claude Code, Hermes, Codex partial; not Grok Build — see matrix)
 - **Multi-Database** — SQLite (default), PostgreSQL, MySQL/MariaDB, or Cloud
 - **Git Worktree Ready** — Each worktree shares the same context database
+
+### Harness compatibility
+
+Not every feature works the same on every client. **Grok Build** uses passive hooks (no stdout injection), so session context and plan-mode hook enforcement are skill-based only (◎).
+
+| Feature | Claude | Codex | Grok | Hermes |
+|---------|:------:|:-----:|:----:|:------:|
+| MCP tools | ✓ | ✓ | ✓ | ✓ |
+| Session context injection | ✓ | △ | — | ✓ |
+| Plan-to-ADR (auto) | ✓ | △ | △ | △ |
+| Plan mode hook enforcement | ✓ | △ | ◎ | ✓ |
+
+✓ full · △ partial · ◎ skills only · ✎ manual MCP · — not available
+
+Full matrix (hooks, **Other harness** column, fallbacks): **[Harness Compatibility](docs/HARNESS_COMPATIBILITY.md)**
 
 ## For Teams (sqlew.io)
 
@@ -205,6 +223,7 @@ name = "your-project-name"
 |-------|-------------|
 | [ADR Concepts](docs/ADR_CONCEPTS.md) | Architecture Decision Records explained |
 | [Configuration](docs/CONFIGURATION.md) | Config file setup, database options |
+| [Harness Compatibility](docs/HARNESS_COMPATIBILITY.md) | Feature × harness matrix (MCP, hooks, session context, Plan-to-ADR) |
 | [Hooks Guide](docs/HOOKS_GUIDE.md) | Claude Code, Codex, Grok Build, and Hermes integration |
 | [Hermes Hooks Guide](docs/HERMES_HOOKS.md) | Hermes-specific setup and wire-protocol notes |
 | [Cross Database](docs/CROSS_DATABASE.md) | Multi-database support |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -81,6 +81,21 @@ Requires `SQLEW_API_KEY` (see [Environment Variables](#environment-variables)).
 
 Authentication, encryption, and scaling are managed by the sqlew cloud service — no local database setup needed.
 
+## [hooks] — Hook Behavior (v5.4.0+)
+
+```toml
+[hooks]
+session_context_budget = 500   # Token budget for session-start context injection (default: 500)
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `session_context_budget` | `500` | Estimated token budget for injected session context. Set to `0` to disable both injection and snapshot writes. Valid range: `0`–`10000` (integer). |
+
+**Priority:** Config loading uses first-match-wins (local `.sqlew/config.toml` > worktree parent > global `~/.config/sqlew/config.toml` > defaults). There is no deep merge — if a local config file exists, global `[hooks]` settings are not applied.
+
+See [HOOKS_GUIDE.md](HOOKS_GUIDE.md#session-context-injection-v540) for architecture and [HARNESS_COMPATIBILITY.md](HARNESS_COMPATIBILITY.md) for per-harness support.
+
 ## [debug] — Debug Logging
 
 ```toml

--- a/docs/HARNESS_COMPATIBILITY.md
+++ b/docs/HARNESS_COMPATIBILITY.md
@@ -1,0 +1,101 @@
+# Harness Compatibility Matrix
+
+Which sqlew features work on which AI harness (client). Install [sqlew-plugin](https://github.com/sqlew-io/sqlew-plugin) for hooks and skills unless you use an **Other harness** setup (MCP server only, no plugin).
+
+**Harnesses:** Claude Code · Codex · Grok Build · Hermes · **Other harness** (MCP tools only — Cursor, Claude Desktop, custom clients, …)
+
+## Legend
+
+| Symbol | Meaning |
+|--------|---------|
+| ✓ | Full support via plugin hooks and/or skills |
+| △ | Partial support, fallback path, or environment-dependent (see notes) |
+| ◎ | Skills only — plugin skill guides the agent; hook stdout injection does not apply |
+| ✎ | Manual — call MCP tools yourself (`decision`, `suggest`, …); no automation |
+| — | Not available |
+
+Minimum sqlew versions: Grok Build **5.2+**, Codex **5.2.1+**, Hermes **5.3.0+**, session context injection **5.4.0+** (unreleased until tagged).
+
+---
+
+## Feature matrix
+
+| Feature | Claude Code | Codex | Grok Build | Hermes | Other harness |
+|---------|:-----------:|:-----:|:----------:|:------:|:--------------:|
+| **MCP tools** (`decision`, `constraint`, `suggest`, `project`, `queue`, …) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **Session context injection** (recent decisions + active constraints at session start) | ✓ | △ | — | ✓ | ✎ |
+| **Plan mode enforcement** (suggest-before-plan, 📌/🚫 format) | ✓ | △ | ◎ | ✓ | ✎ |
+| **Plan-to-ADR extraction** (📌 Decision / 🚫 Constraint → DB) | ✓ | △ | △ | △ | ✎ |
+| **Plan file tracking** (`track-plan`) | ✓ | ✓ | ✓ | ✓ | — |
+| **Decision draft on code edit** (`save` hook) | ✓ | ✓ | ✓ | ✓ | — |
+| **Related-context suggest** (`suggest` on Task / delegate) | ✓ | ✓ | △ | △ | ✎ |
+| **PR ADR guard** (`pr-adr` on `gh pr create`) | ✓ | ✓ | △ | ✓ | — |
+| **Todo completion → decision status** (`check-completion`) | ✓ | ✓ | △ | ✓ | — |
+| **Plan-to-ADR rescue on session clear** (`on-session-start`, source=clear) | ✓ | △ | — | — | — |
+| **PR body ADR enrichment** (`sqlew-pr-adr` skill) | ✓ | ✓ | ◎ | ◎ | — |
+| **Slash command** `/sqlew` | ✓ | △ | △ | — | — |
+| **Desktop project targeting** (`project` tool / `_sqlew_project`) | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+### Other harness — what is this column?
+
+Any client that connects the sqlew MCP server via `.mcp.json` (or MCP settings) **without** sqlew-plugin hooks or skills. Typical cases: Cursor, Claude Desktop, custom MCP clients, `npx @modelcontextprotocol/inspector`.
+
+- ✓ **MCP tools** and **project targeting** work.
+- ✎ Automation (session recall, Plan-to-ADR, suggest-on-task) requires **you or the agent** to call MCP tools explicitly.
+- — Hook-only features (`save`, `track-plan`, `pr-adr`, …) do not run.
+
+See [README — Other harness setup](../README.md#other-harness-mcp-only).
+
+Session context injection (v5.4.0+): see the matrix row above. Config: `[hooks] session_context_budget` in [CONFIGURATION.md](CONFIGURATION.md) (default 500; `0` disables). Architecture: [HOOKS_GUIDE.md](HOOKS_GUIDE.md#session-context-injection-v540).
+
+---
+
+## How to Auto-ADR in each harness
+
+Plan normally, mark architectural choices in the plan, and sqlew saves them to the database. Use these markers in the plan body:
+
+- `### 📌 Decision:` — architectural choice (becomes a decision record)
+- `### 🚫 Constraint:` — rule or limitation (becomes a constraint record)
+
+Plugin skills (`sqlew-decision-format`) remind the agent of this format when needed.
+
+| Harness | How you plan | When ADR is saved | Notes |
+|---------|--------------|-------------------|-------|
+| **Claude Code** | **Plan mode** (`Shift+Tab` or permission mode) | When you **approve the plan** (move to implement) | Best-supported path. If you clear the session without approving, sqlew may rescue on the next session start. |
+| **Codex** | **Plan mode** (enable `[features] collaboration_modes = true` first) | When the agent **stops** after planning | Trust bundled hooks via `/hooks` after install. |
+| **Grok Build** | **Plan mode** | When you **approve the plan** | Skills guide 📌/🚫 format; hooks read `plan.md` on approve (stdout injection is passive). |
+| **Hermes** | **`/plan <prompt>`** (plan skill → `.hermes/plans/*.md`) | When the **plan file is written or updated** | No native Plan mode — extraction runs on plan-file saves; `save` promotes drafts when you edit code. |
+| **Other harness** | No auto flow | When **you** call MCP `decision` / `constraint` | Use `decision set` and `constraint add` explicitly. |
+
+---
+
+## Per-harness quick notes
+
+### Claude Code
+
+Full hook + skill coverage. Best-supported harness.
+
+### Codex
+
+Most hooks work after trusting bundled hooks (`/hooks`). Plan mode needs `collaboration_modes = true`.
+
+### Grok Build
+
+**Passive hooks:** stdout from hooks is ignored except deny JSON on `pre_tool_use`. Plan guidance and decision format come from **skills** (◎). Plan-to-ADR reads `plan.md` when you **approve the plan**. Do not duplicate hooks in `~/.grok/hooks/`.
+
+### Hermes
+
+Context injection only on `pre_llm_call` and `pre_tool_call` block. No `ExitPlanMode` — extraction relies on writes to `.hermes/plans/`. Install via `.hermes-plugin` bundle, not the Claude/Codex manifest.
+
+### Other harness
+
+All eight MCP tools work (✓). No plugin hooks or skills: record and recall decisions by calling MCP tools (✎). Hook-only automation (—) does not run.
+
+---
+
+## Related docs
+
+- [HOOKS_GUIDE.md](HOOKS_GUIDE.md) — Install steps per harness
+- [HERMES_HOOKS.md](HERMES_HOOKS.md) — Hermes wire protocol and config.yaml
+- [CONFIGURATION.md](CONFIGURATION.md) — `[hooks] session_context_budget`
+- [SHARED_DATABASE.md](SHARED_DATABASE.md) — Desktop agents and `project` tool

--- a/docs/HERMES_HOOKS.md
+++ b/docs/HERMES_HOOKS.md
@@ -2,6 +2,8 @@
 
 sqlew Plan-to-ADR hooks for [Hermes](https://github.com/NousResearch/hermes-agent) (Claude Code / Nous). Requires **sqlew >= 5.3.0**.
 
+Cross-harness feature matrix: [HARNESS_COMPATIBILITY.md](HARNESS_COMPATIBILITY.md).
+
 ## Quick Install (recommended)
 
 Use the [sqlew-plugin](https://github.com/sqlew-io/sqlew-plugin) Hermes bundle:
@@ -80,13 +82,13 @@ hermes hooks test pre_llm_call
 | Event names | PascalCase (`PreToolUse`) | snake_case (`pre_tool_call`) — normalized by sqlew |
 | Tool names | `Bash`, `Write`, `Edit` | `terminal`, `write_file`, `patch` — normalized by sqlew |
 | Plan mode | `permission_mode: plan` or Enter/ExitPlanMode | No native plan mode; `plan` skill writes `.hermes/plans/*.md` |
-| Context injection | `UserPromptSubmit`, `PostToolUse` | **`pre_llm_call` only** (`{"context":"..."}`) |
+| Context injection | `SessionStart`, `UserPromptSubmit`, `PostToolUse` | **`pre_llm_call` only** (`{"context":"..."}`) — includes session memory + plan guidance |
 | Tool blocking | PreToolUse deny JSON | **`pre_tool_call` only** (`{"decision":"block","reason"}`) |
 | Plan exit hook | `ExitPlanMode` → `on-exit-plan` | **Not available** — use `track-plan`/`save` on `.hermes/plans/` writes |
 
 ## Plan-to-ADR workflow on Hermes
 
-1. **`pre_llm_call`** — sqlew injects plan guidance every turn (FULL on first prompt in session, SHORT after).
+1. **`pre_llm_call`** — sqlew injects session context (recent decisions + active constraints, first prompt per session) combined with plan guidance in one `{"context":"..."}` line (FULL on first prompt, SHORT after).
 2. **Write plan** — use the `plan` skill; files land in `.hermes/plans/*.md`.
 3. **`track-plan`** — fires on `write_file|patch` to plan paths; caches plan metadata.
 4. **`save`** — promotes decisions when implementation files are edited.

--- a/docs/HOOKS_GUIDE.md
+++ b/docs/HOOKS_GUIDE.md
@@ -2,6 +2,8 @@
 
 sqlew integrates with AI coding assistants through plugins.
 
+> **Feature × harness matrix:** See [HARNESS_COMPATIBILITY.md](HARNESS_COMPATIBILITY.md) for which capabilities (MCP, session context, Plan-to-ADR, PR guard, etc.) work on Claude Code, Codex, Grok Build, Hermes, and other harness setups (MCP only).
+
 ## Prerequisites
 
 Install the sqlew MCP server globally:
@@ -131,8 +133,38 @@ Merged `config.yaml` entries and skills under `~/.hermes/skills/sqlew-*` are not
 | PR enrichment | Skill + Hook | Skill + Hook | Skill + Hook | Hook (`pr-adr`) |
 | Decision format guidance | Skill (sqlew-decision-format) | Skill (sqlew-decision-format) | Skill (sqlew-decision-format) | Skill |
 
+## Session Context Injection (v5.4.0+)
+
+sqlew proactively injects recent decisions and active constraints at session start so agents do not need to call `suggest` first.
+
+### Architecture
+
+The MCP server writes `.sqlew/session-context.json` (top-N decisions + active constraints). Hooks read this file only — they never open the database. This mirrors the existing hook queue (`.sqlew/queue/pending.json`) in the reverse direction.
+
+```
+decision.set / constraint.add  →  session-context.json  →  on-session-start / on-prompt
+```
+
+Snapshot writes are fail-soft: a snapshot failure never fails the primary MCP operation.
+
+Harness support (✓ / △ / — / ◎ / ✎): [HARNESS_COMPATIBILITY.md](HARNESS_COMPATIBILITY.md) feature matrix.
+
+### Configuration
+
+```toml
+[hooks]
+session_context_budget = 500   # default; set 0 to disable injection and snapshot writes
+```
+
+See [CONFIGURATION.md](CONFIGURATION.md) for priority rules (local config overrides global; no deep merge).
+
+### Grok Build limitation
+
+Grok Build hooks are passive — stdout injection is ignored. Session context injection is not available in v5.4. Use `/sqlew search` or the `sqlew-plan-guidance` skill to recall context manually.
+
 ## Version History
 
+- **v5.4.0**: Session context injection (snapshot file, multi-harness delivery, `[hooks]` config)
 - **v5.3.0**: Hermes hook adapter (event/tool normalization, `.hermes/plans`, `pre_llm_call` context injection)
 - **v5.2.1**: Codex plugin support via sqlew-plugin (`.codex-plugin`, marketplace, hook normalization, transcript-based plan extraction)
 - **v5.2.0**: Grok Build support via sqlew-plugin (hook normalization, Grok plan path, skills-based plan guidance)

--- a/src/cli/hooks/on-prompt.ts
+++ b/src/cli/hooks/on-prompt.ts
@@ -8,33 +8,38 @@
  * v5.0.7: First/repeat split - full message with inline template on first
  * prompt, short reminder on subsequent prompts (~80% token reduction).
  *
- * This replaces the previous CLAUDE.md injection approach,
- * providing equivalent always-on enforcement without polluting
- * the user's global ~/.claude/CLAUDE.md.
+ * v5.4.0: Session context injection for Hermes (primary) and Codex (fallback).
  *
  * Usage:
  *   echo '{"hook_event_name":"UserPromptSubmit","permission_mode":"plan"}' | sqlew on-prompt
  *
  * @since v5.0.6
- * @modified v5.0.7 - First/repeat message split, inline template, isPlanMode()
  */
 
 import { randomUUID } from 'crypto';
-import { readStdinJson, isPlanMode, getProjectPath, sendHermesContext } from './stdin-parser.js';
-import { loadCurrentPlan, saveCurrentPlan, type CurrentPlanInfo } from '../../config/global-config.js';
+import {
+  readStdinJson,
+  isPlanMode,
+  getProjectPath,
+  sendHermesContext,
+  type HookInput,
+} from './stdin-parser.js';
+import {
+  loadCurrentPlan,
+  saveCurrentPlan,
+  saveSessionContextMarker,
+  type CurrentPlanInfo,
+} from '../../config/global-config.js';
 import { findCodexTranscriptPath } from './codex-transcript.js';
+import {
+  buildSessionContext,
+  shouldInjectOnPrompt,
+} from './session-context.js';
 
 // ============================================================================
 // Plan Mode Enforcement Context
 // ============================================================================
 
-/**
- * Full enforcement message with inline decision/constraint template.
- * Shown on the first prompt in plan mode (per plan session).
- *
- * Includes the exact 📌/🚫 format so the AI doesn't need to
- * invoke a separate skill — direct embedding improves compliance.
- */
 export const ENFORCEMENT_FULL = `[sqlew] Plan mode active. REQUIRED:
 1. suggest { action: "by_context", key: "<keyword>" } BEFORE planning
 2. Include "Related Context (from sqlew)" section
@@ -52,116 +57,157 @@ export const ENFORCEMENT_FULL = `[sqlew] Plan mode active. REQUIRED:
 
 4. Check queue: queue { action: "list" }`;
 
-/**
- * Short reminder for subsequent prompts in the same plan session.
- * Relies on the full message already being in context.
- */
 export const ENFORCEMENT_SHORT = `[sqlew] Plan guidance active (see format above)`;
 
-/**
- * @deprecated Use ENFORCEMENT_FULL instead. Kept for backwards compatibility
- * with track-plan.ts import.
- */
+/** @deprecated Use ENFORCEMENT_FULL instead. */
 export const PLAN_MODE_ENFORCEMENT = ENFORCEMENT_FULL;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function resolveSessionId(input: HookInput): string | undefined {
+  return input.session_id
+    || process.env.HERMES_SESSION_ID
+    || process.env.CODEX_SESSION_ID;
+}
+
+async function maybeSessionContextBlock(
+  projectPath: string,
+  sessionId: string | undefined,
+  harness: string,
+): Promise<string | null> {
+  if (!shouldInjectOnPrompt(projectPath, sessionId)) {
+    return null;
+  }
+  const block = await buildSessionContext(projectPath);
+  if (block) {
+    saveSessionContextMarker(projectPath, {
+      session_id: sessionId,
+      injected_at: new Date().toISOString(),
+      harness,
+    });
+  }
+  return block;
+}
+
+function combineContext(sessionBlock: string | null, message: string): string {
+  if (sessionBlock) {
+    return [sessionBlock, message].join('\n\n');
+  }
+  return message;
+}
+
+function getHermesEnforcement(projectPath: string): { message: string; planInfo: CurrentPlanInfo | null } {
+  let planInfo = loadCurrentPlan(projectPath);
+  if (!planInfo || !planInfo.enforcement_shown_at) {
+    if (planInfo) {
+      planInfo.enforcement_shown_at = new Date().toISOString();
+      saveCurrentPlan(projectPath, planInfo);
+    } else {
+      planInfo = {
+        plan_id: randomUUID(),
+        plan_file: 'hermes-plan.md',
+        plan_updated_at: new Date().toISOString(),
+        recorded: false,
+        decision_pending: true,
+        enforcement_shown_at: new Date().toISOString(),
+      };
+      saveCurrentPlan(projectPath, planInfo);
+    }
+    return { message: ENFORCEMENT_FULL, planInfo };
+  }
+  return { message: ENFORCEMENT_SHORT, planInfo };
+}
 
 // ============================================================================
 // Main Entry Point
 // ============================================================================
 
-/**
- * Main on-prompt command entry point
- *
- * Called as UserPromptSubmit hook on every user prompt.
- * Only injects enforcement context when permission_mode is "plan".
- *
- * First prompt in a plan session gets the full message with inline template.
- * Subsequent prompts get a short 1-line reminder (~80% token reduction).
- */
 export async function onPromptCommand(): Promise<void> {
   try {
     const input = await readStdinJson();
 
-    // Grok Build: UserPromptSubmit is a passive hook — stdout is ignored.
-    // Plan mode guidance is delivered via plugin skills instead.
     if (input.client === 'grok') {
       return;
     }
 
-    // Hermes: pre_llm_call is the only context-injection point and there is no
-    // plan permission mode. Inject FULL guidance once per session, SHORT after.
+    const projectPath = getProjectPath(input);
+    const sessionId = resolveSessionId(input);
+
+    // Hermes: pre_llm_call — session context + plan guidance in one JSON line
     if (input.client === 'hermes') {
-      const hermesProjectPath = getProjectPath(input);
-      if (!hermesProjectPath) {
+      if (!projectPath) {
         sendHermesContext(ENFORCEMENT_FULL);
         return;
       }
 
-      let hermesPlanInfo = loadCurrentPlan(hermesProjectPath);
-      if (!hermesPlanInfo || !hermesPlanInfo.enforcement_shown_at) {
-        sendHermesContext(ENFORCEMENT_FULL);
-        if (hermesPlanInfo) {
-          hermesPlanInfo.enforcement_shown_at = new Date().toISOString();
-          saveCurrentPlan(hermesProjectPath, hermesPlanInfo);
-        } else {
-          const info: CurrentPlanInfo = {
-            plan_id: randomUUID(),
-            plan_file: 'hermes-plan.md',
-            plan_updated_at: new Date().toISOString(),
-            recorded: false,
-            decision_pending: true,
-            enforcement_shown_at: new Date().toISOString(),
-          };
-          saveCurrentPlan(hermesProjectPath, info);
+      const sessionBlock = await maybeSessionContextBlock(projectPath, sessionId, 'hermes');
+      const { message } = getHermesEnforcement(projectPath);
+      sendHermesContext(combineContext(sessionBlock, message));
+      return;
+    }
+
+    // Codex: session context fallback (before plan-mode early return)
+    if (input.client === 'codex' && projectPath) {
+      const sessionBlock = await maybeSessionContextBlock(projectPath, sessionId, 'codex');
+
+      if (!isPlanMode(input)) {
+        if (sessionBlock) {
+          process.stdout.write(sessionBlock);
         }
-      } else {
-        sendHermesContext(ENFORCEMENT_SHORT);
+        return;
       }
+
+      // Plan mode: combine session context with enforcement below
+      let planInfo = loadCurrentPlan(projectPath);
+
+      if (!planInfo) {
+        const transcriptPath =
+          input.transcript_path ||
+          (input.session_id ? findCodexTranscriptPath(input.session_id) : undefined) ||
+          undefined;
+        const codexPlanInfo: CurrentPlanInfo = {
+          plan_id: randomUUID(),
+          plan_file: 'codex-plan.md',
+          plan_path: transcriptPath,
+          plan_updated_at: new Date().toISOString(),
+          recorded: false,
+          decision_pending: true,
+        };
+        saveCurrentPlan(projectPath, codexPlanInfo);
+        planInfo = codexPlanInfo;
+      }
+
+      const enforcement = (!planInfo.enforcement_shown_at) ? ENFORCEMENT_FULL : ENFORCEMENT_SHORT;
+      if (!planInfo.enforcement_shown_at) {
+        planInfo.enforcement_shown_at = new Date().toISOString();
+        saveCurrentPlan(projectPath, planInfo);
+      }
+
+      process.stdout.write(combineContext(sessionBlock, enforcement));
       return;
     }
 
     if (!isPlanMode(input)) {
-      // Non-plan mode: output nothing (exit 0 = allow, no context injection)
       return;
     }
 
-    // Determine first vs repeat using session cache
-    const projectPath = getProjectPath(input);
+    // Claude plan mode (session context injected via SessionStart, not here)
     if (!projectPath) {
-      // Fallback: always show full message if project path unknown
       process.stdout.write(ENFORCEMENT_FULL);
       return;
     }
 
     let planInfo = loadCurrentPlan(projectPath);
 
-    if (input.client === 'codex' && !planInfo) {
-      const transcriptPath =
-        input.transcript_path ||
-        (input.session_id ? findCodexTranscriptPath(input.session_id) : undefined) ||
-        undefined;
-      const codexPlanInfo: CurrentPlanInfo = {
-        plan_id: randomUUID(),
-        plan_file: 'codex-plan.md',
-        plan_path: transcriptPath,
-        plan_updated_at: new Date().toISOString(),
-        recorded: false,
-        decision_pending: true,
-      };
-      saveCurrentPlan(projectPath, codexPlanInfo);
-      planInfo = codexPlanInfo;
-    }
-
     if (!planInfo || !planInfo.enforcement_shown_at) {
-      // First prompt in this plan session → full message with inline template
       process.stdout.write(ENFORCEMENT_FULL);
-
-      // Mark enforcement as shown
       if (planInfo) {
         planInfo.enforcement_shown_at = new Date().toISOString();
         saveCurrentPlan(projectPath, planInfo);
       }
     } else {
-      // Subsequent prompt → short reminder
       process.stdout.write(ENFORCEMENT_SHORT);
     }
   } catch {

--- a/src/cli/hooks/on-session-start.ts
+++ b/src/cli/hooks/on-session-start.ts
@@ -5,8 +5,8 @@
  * When source is "clear", triggers Plan-to-ADR processing for cached plans
  * that weren't processed by PostToolUse:ExitPlanMode (due to session clear).
  *
- * This fixes the issue where "Yes, clear context and auto-accept edits"
- * selection skips PostToolUse:ExitPlanMode hook.
+ * v5.4.0: Injects session context (recent decisions + active constraints)
+ * on startup/clear for Claude Code and Codex.
  *
  * Usage:
  *   echo '{"hook_event_name": "SessionStart", "source": "clear", "cwd": "/path"}' | sqlew on-session-start
@@ -14,60 +14,77 @@
  * @since v5.0.0
  */
 
-import { readStdinJson, sendContinue, getProjectPath } from './stdin-parser.js';
+import {
+  readStdinJson,
+  sendContinue,
+  sendSessionStartContext,
+  getProjectPath,
+} from './stdin-parser.js';
 import { processPlanPatterns } from './plan-processor.js';
-import { loadCurrentPlan, clearCurrentPlan } from '../../config/global-config.js';
+import {
+  loadCurrentPlan,
+  clearCurrentPlan,
+  saveSessionContextMarker,
+} from '../../config/global-config.js';
+import { buildSessionContext } from './session-context.js';
 
 // ============================================================================
 // Main Entry Point
 // ============================================================================
 
 /**
+ * Process Plan-to-ADR rescue for source=clear sessions.
+ */
+function processClearPlanRescue(projectPath: string): void {
+  const cachedPlan = loadCurrentPlan(projectPath);
+  if (!cachedPlan) {
+    return;
+  }
+
+  if (cachedPlan.recorded) {
+    clearCurrentPlan(projectPath);
+    return;
+  }
+
+  const result = processPlanPatterns(projectPath);
+  clearCurrentPlan(projectPath);
+
+  if (result.processed && result.confirmationMessage) {
+    console.error(`[sqlew on-session-start] ${result.confirmationMessage}`);
+  }
+}
+
+/**
  * Main on-session-start command entry point
- *
- * Called as SessionStart hook when a new session begins.
- * Only processes "clear" source to handle Plan-to-ADR for cached plans.
  */
 export async function onSessionStartCommand(): Promise<void> {
   try {
     const input = await readStdinJson();
-
-    // Only process "clear" source (Plan mode with "clear context" approval)
-    if (input.source !== 'clear') {
-      sendContinue();
-      return;
-    }
-
     const projectPath = getProjectPath(input);
-    if (!projectPath) {
-      sendContinue();
-      return;
+    const client = input.client ?? 'claude';
+    const source = input.source ?? 'startup';
+
+    // Plan-to-ADR rescue for "clear" source (unchanged behavior)
+    if (input.source === 'clear' && projectPath) {
+      processClearPlanRescue(projectPath);
     }
 
-    // Check if there's a cached plan waiting to be processed
-    const cachedPlan = loadCurrentPlan(projectPath);
-    if (!cachedPlan) {
-      // No cached plan - nothing to process
-      sendContinue();
-      return;
-    }
+    // Session context injection: Claude/Codex on startup or clear only
+    const shouldInject =
+      (client === 'claude' || client === 'codex') &&
+      (source === 'startup' || source === 'clear');
 
-    // Skip if already recorded (shouldn't happen, but safety check)
-    if (cachedPlan.recorded) {
-      clearCurrentPlan(projectPath);
-      sendContinue();
-      return;
-    }
-
-    // Process the cached plan (extract patterns and queue to pending.json)
-    const result = processPlanPatterns(projectPath);
-
-    // Clear cache after processing (regardless of result)
-    clearCurrentPlan(projectPath);
-
-    if (result.processed && result.confirmationMessage) {
-      // Log confirmation to stderr (visible in debug logs)
-      console.error(`[sqlew on-session-start] ${result.confirmationMessage}`);
+    if (shouldInject && projectPath) {
+      const context = await buildSessionContext(projectPath);
+      if (context) {
+        saveSessionContextMarker(projectPath, {
+          session_id: input.session_id,
+          injected_at: new Date().toISOString(),
+          harness: client,
+        });
+        sendSessionStartContext(context);
+        return;
+      }
     }
 
     sendContinue();

--- a/src/cli/hooks/session-context.ts
+++ b/src/cli/hooks/session-context.ts
@@ -1,0 +1,182 @@
+/**
+ * Session context injection helpers for hooks
+ *
+ * Reads .sqlew/session-context.json (written by MCP server) and formats
+ * a budget-trimmed context block for hook injection. Hooks never open the DB.
+ *
+ * @since v5.4.0
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { GitAdapter } from '../../utils/vcs-adapter.js';
+import { resolveConfigPath, loadConfigFile } from '../../config/loader.js';
+import { loadGlobalConfig } from '../../config/global-config.js';
+import {
+  DEFAULT_SESSION_CONTEXT_BUDGET,
+} from '../../config/types.js';
+import {
+  SESSION_SNAPSHOT_VERSION,
+  type SessionSnapshot,
+} from '../../utils/session-snapshot.js';
+import { estimateTokens } from '../../utils/token-estimation.js';
+import {
+  loadSessionContextMarker,
+  type SessionContextMarker,
+} from '../../config/global-config.js';
+
+const STALENESS_DAYS = 30;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Resolve candidate snapshot paths (local + worktree parent fallback)
+ */
+async function resolveSnapshotPaths(projectPath: string): Promise<string[]> {
+  const paths: string[] = [
+    join(projectPath, '.sqlew', 'session-context.json'),
+  ];
+
+  const gitAdapter = new GitAdapter(projectPath);
+  if (await gitAdapter.isWorktree()) {
+    const mainRoot = await gitAdapter.getMainRepositoryRoot();
+    if (mainRoot) {
+      paths.push(join(mainRoot, '.sqlew', 'session-context.json'));
+    }
+  }
+
+  return paths;
+}
+
+/**
+ * Load session snapshot from disk. Returns null if missing, stale, or invalid.
+ */
+export async function loadSnapshot(projectPath: string): Promise<SessionSnapshot | null> {
+  const candidates = await resolveSnapshotPaths(projectPath);
+
+  for (const snapshotPath of candidates) {
+    if (!existsSync(snapshotPath)) {
+      continue;
+    }
+
+    try {
+      const snapshot = JSON.parse(readFileSync(snapshotPath, 'utf-8')) as SessionSnapshot;
+
+      if (snapshot.version !== SESSION_SNAPSHOT_VERSION) {
+        continue;
+      }
+
+      const generatedAt = new Date(snapshot.generated_at).getTime();
+      if (Number.isNaN(generatedAt)) {
+        continue;
+      }
+
+      const ageMs = Date.now() - generatedAt;
+      if (ageMs > STALENESS_DAYS * MS_PER_DAY) {
+        continue;
+      }
+
+      return snapshot;
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolve session context token budget from config (local → global → default).
+ */
+export async function resolveBudget(projectPath: string): Promise<number> {
+  const configPath = await resolveConfigPath(projectPath);
+  if (configPath) {
+    const configDir = dirname(configPath);
+    const configFile = configPath.slice(configDir.length + 1);
+    const config = loadConfigFile(configDir, configFile);
+    return config.hooks?.session_context_budget ?? DEFAULT_SESSION_CONTEXT_BUDGET;
+  }
+
+  const globalConfig = loadGlobalConfig();
+  return globalConfig.hooks?.session_context_budget ?? DEFAULT_SESSION_CONTEXT_BUDGET;
+}
+
+/**
+ * Format snapshot into an English Markdown context block, trimmed to budget.
+ * Returns null when budget is 0 or both lists are empty.
+ */
+export function formatContextBlock(snapshot: SessionSnapshot, budget: number): string | null {
+  if (budget <= 0) {
+    return null;
+  }
+
+  if (snapshot.decisions.length === 0 && snapshot.constraints.length === 0) {
+    return null;
+  }
+
+  const lines: string[] = ['[sqlew] Session context (auto-injected)'];
+
+  if (snapshot.constraints.length > 0) {
+    lines.push('', '### Active Constraints');
+    for (const c of snapshot.constraints) {
+      lines.push(`- **${c.category}** (${c.priority}): ${c.rule}`);
+      if (c.reason) {
+        lines.push(`  Reason: ${c.reason}`);
+      }
+    }
+  }
+
+  if (snapshot.decisions.length > 0) {
+    lines.push('', '### Recent Decisions');
+    for (const d of snapshot.decisions) {
+      const meta = [d.layer, d.updated].filter(Boolean).join(', ');
+      lines.push(`- **${d.key}**: ${d.value}${meta ? ` (${meta})` : ''}`);
+    }
+  }
+
+  let block = lines.join('\n');
+
+  while (estimateTokens(block) > budget && block.includes('\n')) {
+    const trimmed = block.slice(0, block.lastIndexOf('\n'));
+    if (trimmed === block) {
+      break;
+    }
+    block = trimmed;
+  }
+
+  if (estimateTokens(block) > budget) {
+    const maxChars = budget * 4;
+    block = block.slice(0, maxChars);
+  }
+
+  return block.trim().length > 0 ? block : null;
+}
+
+/**
+ * Whether on-prompt should inject session context (Codex/Hermes fallback).
+ * Returns false when session_id is unavailable to prevent per-prompt spam.
+ */
+export function shouldInjectOnPrompt(
+  projectPath: string,
+  sessionId: string | undefined,
+): boolean {
+  if (sessionId == null) {
+    return false;
+  }
+
+  const marker = loadSessionContextMarker(projectPath);
+  return marker?.session_id !== sessionId;
+}
+
+/**
+ * Build formatted session context block for injection.
+ */
+export async function buildSessionContext(projectPath: string): Promise<string | null> {
+  const budget = await resolveBudget(projectPath);
+  const snapshot = await loadSnapshot(projectPath);
+  if (!snapshot) {
+    return null;
+  }
+  return formatContextBlock(snapshot, budget);
+}
+
+export type { SessionContextMarker };

--- a/src/cli/hooks/stdin-parser.ts
+++ b/src/cli/hooks/stdin-parser.ts
@@ -125,6 +125,17 @@ export interface PostToolUseHookOutput {
 }
 
 /**
+ * Hook-specific output for SessionStart (v5.4.0+)
+ * Used for injecting context at session start
+ */
+export interface SessionStartHookOutput {
+  /** Hook event name */
+  hookEventName: 'SessionStart';
+  /** Additional context to inject into Claude's context */
+  additionalContext?: string;
+}
+
+/**
  * Hook output to Claude Code
  */
 export interface HookOutput {
@@ -138,8 +149,8 @@ export interface HookOutput {
   systemMessage?: string;
   /** Whether to suppress output */
   suppressOutput?: boolean;
-  /** Hook-specific output (PreToolUse, PostToolUse) - v4.2.0+ */
-  hookSpecificOutput?: PreToolUseHookOutput | PostToolUseHookOutput;
+  /** Hook-specific output (PreToolUse, PostToolUse, SessionStart) - v4.2.0+ */
+  hookSpecificOutput?: PreToolUseHookOutput | PostToolUseHookOutput | SessionStartHookOutput;
   /** @deprecated Use hookSpecificOutput.updatedInput instead */
   updatedInput?: ToolInput;
 }
@@ -521,6 +532,26 @@ export function sendPostToolUseContext(additionalContext: string): void {
     continue: true,
     hookSpecificOutput: {
       hookEventName: 'PostToolUse',
+      additionalContext,
+    },
+  };
+  writeHookOutput(output);
+}
+
+/**
+ * Send a continue response with context for SessionStart
+ *
+ * Uses both top-level additionalContext and hookSpecificOutput for compatibility.
+ * Integration tests verify no double injection; drop top-level if duplicated.
+ *
+ * @param additionalContext - Context to inject at session start
+ */
+export function sendSessionStartContext(additionalContext: string): void {
+  const output: HookOutput = {
+    continue: true,
+    additionalContext,
+    hookSpecificOutput: {
+      hookEventName: 'SessionStart',
       additionalContext,
     },
   };

--- a/src/config/global-config.ts
+++ b/src/config/global-config.ts
@@ -58,6 +58,13 @@ export interface GlobalDebugConfig {
 }
 
 /**
+ * Hooks configuration (v5.4.0+)
+ */
+export interface GlobalHooksConfig {
+  session_context_budget?: number;
+}
+
+/**
  * Global configuration structure
  * Stored in user's home directory, applies to all projects
  */
@@ -70,6 +77,8 @@ export interface GlobalConfig {
   autodelete?: GlobalAutodeleteConfig;
   /** Debug settings */
   debug?: GlobalDebugConfig;
+  /** Hooks settings (v5.4.0+) */
+  hooks?: GlobalHooksConfig;
 }
 
 /**
@@ -274,6 +283,10 @@ const CONFIG_TOML_TEMPLATE = `# ~/.config/sqlew/config.toml - Global sqlew confi
 
 # SaaS/Cloud mode:
 # type = "cloud"
+
+[hooks]
+# Token budget for session-start context injection (default: 500, 0 = disabled)
+# session_context_budget = 500
 `;
 
 /**
@@ -328,6 +341,7 @@ export function loadGlobalConfig(): GlobalConfig {
       database: parsed.database,
       autodelete: parsed.autodelete,
       debug: parsed.debug,
+      hooks: parsed.hooks,
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -377,6 +391,50 @@ export interface CurrentPlanInfo {
   decision_pending?: boolean;
   /** ISO 8601 timestamp of when full enforcement message was first shown */
   enforcement_shown_at?: string;
+}
+
+/**
+ * Session context injection marker (dedup across SessionStart / on-prompt)
+ *
+ * @since v5.4.0
+ */
+export interface SessionContextMarker {
+  session_id?: string;
+  injected_at: string;
+  harness: string;
+}
+
+/**
+ * Get the session context marker file path for a project
+ *
+ * @param projectPath - Project root path
+ * @returns Absolute path to context marker file
+ */
+export function getSessionContextMarkerPath(projectPath: string): string {
+  return getSessionCachePath(projectPath).replace(/\.json$/, '.context.json');
+}
+
+/**
+ * Load session context injection marker for a project
+ */
+export function loadSessionContextMarker(projectPath: string): SessionContextMarker | null {
+  const markerPath = getSessionContextMarkerPath(projectPath);
+  if (!existsSync(markerPath)) {
+    return null;
+  }
+  try {
+    return JSON.parse(readFileSync(markerPath, 'utf-8')) as SessionContextMarker;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save session context injection marker for a project
+ */
+export function saveSessionContextMarker(projectPath: string, marker: SessionContextMarker): void {
+  const markerPath = getSessionContextMarkerPath(projectPath);
+  writeFileSync(markerPath, JSON.stringify(marker, null, 2), 'utf-8');
 }
 
 /**

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -64,6 +64,10 @@ export function loadConfigFile(projectRoot: string = process.cwd(), configPath?:
         ...DEFAULT_CONFIG.debug,
         ...parsed.debug,
       },
+      hooks: {
+        ...DEFAULT_CONFIG.hooks,
+        ...parsed.hooks,
+      },
     };
 
     // Validate the merged configuration
@@ -258,6 +262,14 @@ export function validateConfig(config: SqlewConfig): { valid: boolean; errors: s
       if (config.autodelete.file_history_days < 1 || config.autodelete.file_history_days > 365) {
         errors.push('autodelete.file_history_days must be between 1 and 365');
       }
+    }
+  }
+
+  // Validate hooks settings
+  if (config.hooks?.session_context_budget !== undefined) {
+    const budget = config.hooks.session_context_budget;
+    if (!Number.isInteger(budget) || budget < 0 || budget > 10000) {
+      errors.push('hooks.session_context_budget must be an integer between 0 and 10000');
     }
   }
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -289,6 +289,20 @@ export interface DebugConfig {
 }
 
 /**
+ * Hooks configuration (v5.4.0+)
+ */
+export interface HooksConfig {
+  /**
+   * Token budget for session-start context injection.
+   * Default: 500. Set to 0 to disable injection and snapshot writes.
+   */
+  session_context_budget?: number;
+}
+
+/** Default session context injection token budget */
+export const DEFAULT_SESSION_CONTEXT_BUDGET = 500;
+
+/**
  * Project configuration (v3.7.0+)
  *
  * Multi-project support requires explicit project identification.
@@ -395,6 +409,8 @@ export interface SqlewConfig {
   autodelete?: AutoDeleteConfig;
   /** Debug logging settings */
   debug?: DebugConfig;
+  /** Hooks settings (v5.4.0+) */
+  hooks?: HooksConfig;
 }
 
 /**
@@ -408,5 +424,8 @@ export const DEFAULT_CONFIG: SqlewConfig = {
     ignore_weekend: false,
     message_hours: 24,
     file_history_days: 7,
+  },
+  hooks: {
+    session_context_budget: DEFAULT_SESSION_CONTEXT_BUDGET,
   },
 };

--- a/src/init-rules.ts
+++ b/src/init-rules.ts
@@ -102,6 +102,7 @@ export function initializeSqlewRules(projectRoot: string): void {
 const SQLEW_GITIGNORE_ENTRIES = [
   'queue/',
   'tmp/',
+  'session-context.json',
 ];
 
 /** Marker comment for sqlew gitignore */

--- a/src/server/setup.ts
+++ b/src/server/setup.ts
@@ -21,6 +21,7 @@ import { ensureProjectConfig } from '../config/writer.js';
 import { ProjectContext } from '../utils/project-context.js';
 import { detectVCS, GitAdapter } from '../utils/vcs-adapter.js';
 import { startQueueWatcher } from '../watcher/queue-watcher.js';
+import { refreshSnapshotNow } from '../utils/session-snapshot.js';
 import { initDebugLogger, debugLog } from '../utils/debug-logger.js';
 import { ensureSqlewDirectory } from '../config/example-generator.js';
 import { determineProjectRoot, isAmbiguousProjectRoot, wasProjectRootExplicit } from '../utils/project-root.js';
@@ -137,6 +138,7 @@ async function loadConfigWithPriority(
       database: mergedDatabase,
       autodelete: { ...DEFAULT_CONFIG.autodelete, ...globalConfig.autodelete },
       debug: { ...DEFAULT_CONFIG.debug, ...globalConfig.debug },
+      hooks: { ...DEFAULT_CONFIG.hooks, ...globalConfig.hooks },
     };
     return {
       config,
@@ -419,6 +421,13 @@ export async function initializeServer(parsedArgs: ParsedArgs): Promise<SetupRes
   } catch (error) {
     debugLog('WARN', 'Failed to start queue watcher', { error });
     // Non-fatal - hooks will still enqueue, processed on next startup
+  }
+
+  // 10. Write initial session context snapshot for hook injection
+  try {
+    await refreshSnapshotNow();
+  } catch (error) {
+    debugLog('WARN', 'Failed to refresh session snapshot', { error });
   }
 
   return {

--- a/src/tests/feature/session-snapshot/snapshot.test.ts
+++ b/src/tests/feature/session-snapshot/snapshot.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Session snapshot feature tests
+ *
+ * @since v5.4.0
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { getAdapter, initializeDatabase, closeDatabase } from '../../../database.js';
+import { ProjectContext } from '../../../utils/project-context.js';
+import { setDecision } from '../../../tools/context/index.js';
+import { setDecisionBatch } from '../../../tools/context/actions/batch-set.js';
+import { addConstraint, deactivateConstraint } from '../../../tools/constraints/index.js';
+import {
+  getSnapshotPath,
+  readSessionSnapshot,
+  refreshSnapshotNow,
+  flushSnapshotRefresh,
+  SESSION_SNAPSHOT_VERSION,
+  MAX_SNAPSHOT_DECISIONS,
+} from '../../../utils/session-snapshot.js';
+
+const TEST_DB_PATH = '.tmp-test/session-snapshot.db';
+let testProjectRoot: string;
+let testProjectName: string;
+
+describe('session-snapshot', () => {
+  before(async () => {
+    mkdirSync('.tmp-test', { recursive: true });
+    testProjectRoot = join(tmpdir(), `sqlew-snapshot-${Date.now()}`);
+    testProjectName = `test-session-snapshot-${Date.now()}`;
+    mkdirSync(join(testProjectRoot, '.sqlew'), { recursive: true });
+
+    const adapter = await initializeDatabase({
+      databaseType: 'sqlite',
+      connection: { filename: TEST_DB_PATH },
+    });
+
+    const knex = adapter.getKnex();
+    ProjectContext.reset();
+    const projectContext = ProjectContext.getInstance();
+    await projectContext.ensureProject(knex, testProjectName, 'config', {
+      projectRootPath: testProjectRoot,
+    });
+  });
+
+  after(async () => {
+    await closeDatabase();
+    if (existsSync(testProjectRoot)) {
+      rmSync(testProjectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('should write snapshot after decision set', async () => {
+    await setDecision({
+      key: 'snapshot/test-decision',
+      value: 'Use snapshot architecture',
+      layer: 'infrastructure',
+      tags: ['hooks', 'snapshot'],
+    });
+    await flushSnapshotRefresh();
+
+    const snapshot = readSessionSnapshot(testProjectRoot);
+    assert.ok(snapshot, 'snapshot file should exist');
+    assert.strictEqual(snapshot!.version, SESSION_SNAPSHOT_VERSION);
+    assert.ok(
+      snapshot!.decisions.some(d => d.key === 'snapshot/test-decision'),
+      'decision should appear in snapshot',
+    );
+  });
+
+  it('should write snapshot after constraint add', async () => {
+    await addConstraint({
+      category: 'architecture',
+      constraint_text: 'snapshot-test-constraint-rule',
+      priority: 'high',
+      reason: 'Test reason for snapshot',
+    });
+    await flushSnapshotRefresh();
+
+    const snapshot = readSessionSnapshot(testProjectRoot);
+    assert.ok(snapshot);
+    assert.ok(
+      snapshot!.constraints.some(c => c.rule === 'snapshot-test-constraint-rule'),
+      'constraint should appear in snapshot',
+    );
+  });
+
+  it('should remove constraint from snapshot after deactivate', async () => {
+    const addResult = await addConstraint({
+      category: 'security',
+      constraint_text: 'snapshot-deactivate-test',
+      priority: 'medium',
+    });
+    await flushSnapshotRefresh();
+
+    await deactivateConstraint({ id: addResult.constraint_id });
+    await flushSnapshotRefresh();
+
+    const snapshot = readSessionSnapshot(testProjectRoot);
+    assert.ok(snapshot);
+    assert.ok(
+      !snapshot!.constraints.some(c => c.rule === 'snapshot-deactivate-test'),
+      'deactivated constraint should not appear in snapshot',
+    );
+  });
+
+  it('should debounce batch_set into a single snapshot write', async () => {
+    const batch = Array.from({ length: 3 }, (_, i) => ({
+      key: `snapshot/batch-${i}`,
+      value: `batch value ${i}`,
+      layer: 'business',
+    }));
+
+    await setDecisionBatch({ decisions: batch });
+    await flushSnapshotRefresh();
+
+    const snapshot = readSessionSnapshot(testProjectRoot);
+    assert.ok(snapshot);
+    const batchKeys = batch.map(b => b.key);
+    const found = snapshot!.decisions.filter(d => batchKeys.includes(d.key));
+    assert.strictEqual(found.length, 3);
+  });
+
+  it('should cap decisions at MAX_SNAPSHOT_DECISIONS', async () => {
+    const extra = Array.from({ length: MAX_SNAPSHOT_DECISIONS + 2 }, (_, i) => ({
+      key: `snapshot/cap-${i}`,
+      value: `cap test ${i}`,
+      layer: 'business',
+    }));
+    await setDecisionBatch({ decisions: extra });
+    await refreshSnapshotNow();
+
+    const snapshot = readSessionSnapshot(testProjectRoot);
+    assert.ok(snapshot);
+    assert.ok(snapshot!.decisions.length <= MAX_SNAPSHOT_DECISIONS);
+  });
+
+  it('should write atomically to session-context.json', async () => {
+    await refreshSnapshotNow();
+    const snapshotPath = getSnapshotPath(testProjectRoot);
+    assert.ok(existsSync(snapshotPath));
+    const snapshot = readSessionSnapshot(testProjectRoot);
+    assert.ok(snapshot?.generated_at);
+    assert.ok(Array.isArray(snapshot!.decisions));
+    assert.ok(Array.isArray(snapshot!.constraints));
+  });
+});

--- a/src/tests/integration/hermes-on-prompt.test.ts
+++ b/src/tests/integration/hermes-on-prompt.test.ts
@@ -4,11 +4,21 @@
  * @since v5.3.0
  */
 
-import { describe, it } from 'node:test';
-import assert from 'node:assert';
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync } from 'fs';
 import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  writeSessionSnapshot,
+  SESSION_SNAPSHOT_VERSION,
+} from '../../utils/session-snapshot.js';
+import {
+  saveSessionContextMarker,
+  saveCurrentPlan,
+  getSessionContextMarkerPath,
+} from '../../config/global-config.js';
 
 const projectRoot = join(import.meta.dirname, '../../..');
 const distEntry = join(projectRoot, 'dist/index.js');
@@ -23,8 +33,28 @@ function runHook(cmd: string, payload: object, env: Record<string, string> = {})
 }
 
 describe('on-prompt (Hermes)', () => {
-  it('emits {context} JSON for a Hermes pre_llm_call', () => {
+  let testProjectPath: string;
+
+  beforeEach(() => {
     assert.ok(existsSync(distEntry), 'dist/index.js missing — run npm run build first');
+    testProjectPath = join(tmpdir(), `sqlew-hermes-${Date.now()}`);
+    mkdirSync(join(testProjectPath, '.sqlew'), { recursive: true });
+    writeSessionSnapshot(testProjectPath, {
+      version: SESSION_SNAPSHOT_VERSION,
+      project_name: 'hermes-test',
+      generated_at: new Date().toISOString(),
+      decisions: [{ key: 'hermes/decision', value: 'memory block content', updated: '2026-07-02' }],
+      constraints: [],
+    });
+  });
+
+  afterEach(() => {
+    if (existsSync(testProjectPath)) {
+      rmSync(testProjectPath, { recursive: true, force: true });
+    }
+  });
+
+  it('emits {context} JSON for a Hermes pre_llm_call', () => {
     const out = runHook(
       'on-prompt',
       {
@@ -37,5 +67,70 @@ describe('on-prompt (Hermes)', () => {
     );
     const parsed = JSON.parse(out.trim());
     assert.ok(typeof parsed.context === 'string' && parsed.context.includes('sqlew'));
+  });
+
+  it('combines session context + FULL guidance on first pre_llm_call', () => {
+    const out = runHook(
+      'on-prompt',
+      {
+        hook_event_name: 'pre_llm_call',
+        cwd: testProjectPath,
+        session_id: 'hermes-first',
+      },
+      { HERMES_SESSION_ID: 'hermes-first' },
+    );
+    const parsed = JSON.parse(out.trim());
+    assert.ok(parsed.context.includes('memory block content'));
+    assert.ok(parsed.context.includes('Plan mode active'));
+  });
+
+  it('emits SHORT guidance only on second call with same session_id', () => {
+    saveSessionContextMarker(testProjectPath, {
+      session_id: 'hermes-repeat',
+      injected_at: new Date().toISOString(),
+      harness: 'hermes',
+    });
+    saveCurrentPlan(testProjectPath, {
+      plan_id: 'plan-repeat',
+      plan_file: 'hermes-plan.md',
+      plan_updated_at: new Date().toISOString(),
+      recorded: false,
+      enforcement_shown_at: new Date().toISOString(),
+    });
+
+    const out = runHook(
+      'on-prompt',
+      {
+        hook_event_name: 'pre_llm_call',
+        cwd: testProjectPath,
+        session_id: 'hermes-repeat',
+      },
+      { HERMES_SESSION_ID: 'hermes-repeat' },
+    );
+    const parsed = JSON.parse(out.trim());
+    assert.ok(!parsed.context.includes('memory block content'));
+    assert.ok(parsed.context.includes('Plan guidance active'));
+  });
+
+  it('deduplicates Codex session context via marker', () => {
+    saveSessionContextMarker(testProjectPath, {
+      session_id: 'codex-same',
+      injected_at: new Date().toISOString(),
+      harness: 'codex',
+    });
+
+    const out = runHook(
+      'on-prompt',
+      {
+        hook_event_name: 'UserPromptSubmit',
+        cwd: testProjectPath,
+        session_id: 'codex-same',
+        collaboration_mode: 'default',
+      },
+      { CODEX_SESSION_ID: 'codex-same' },
+    );
+
+    assert.strictEqual(out.trim(), '');
+    assert.ok(existsSync(getSessionContextMarkerPath(testProjectPath)));
   });
 });

--- a/src/tests/integration/session-start-injection.test.ts
+++ b/src/tests/integration/session-start-injection.test.ts
@@ -1,0 +1,108 @@
+/**
+ * SessionStart context injection integration tests
+ *
+ * @since v5.4.0
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  writeSessionSnapshot,
+  SESSION_SNAPSHOT_VERSION,
+} from '../../utils/session-snapshot.js';
+
+const projectRoot = join(import.meta.dirname, '../../..');
+const distEntry = join(projectRoot, 'dist/index.js');
+
+function runHook(cmd: string, payload: object, env: Record<string, string> = {}): string {
+  return execFileSync('node', [distEntry, cmd], {
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+    cwd: projectRoot,
+    env: { ...process.env, ...env },
+  });
+}
+
+describe('on-session-start injection', () => {
+  let testProjectPath: string;
+
+  beforeEach(() => {
+    assert.ok(existsSync(distEntry), 'dist/index.js missing — run npm run build first');
+    testProjectPath = join(tmpdir(), `sqlew-ss-${Date.now()}`);
+    mkdirSync(join(testProjectPath, '.sqlew'), { recursive: true });
+    writeSessionSnapshot(testProjectPath, {
+      version: SESSION_SNAPSHOT_VERSION,
+      project_name: 'integration-test',
+      generated_at: new Date().toISOString(),
+      decisions: [{ key: 'hooks/test', value: 'injected decision', updated: '2026-07-02' }],
+      constraints: [{ category: 'architecture', rule: 'no db in hooks', priority: 'high' }],
+    });
+  });
+
+  afterEach(() => {
+    if (existsSync(testProjectPath)) {
+      rmSync(testProjectPath, { recursive: true, force: true });
+    }
+  });
+
+  it('should inject context on Claude startup', () => {
+    const out = runHook('on-session-start', {
+      hook_event_name: 'SessionStart',
+      source: 'startup',
+      cwd: testProjectPath,
+      session_id: 's-startup-1',
+    });
+    const parsed = JSON.parse(out.trim());
+    assert.strictEqual(parsed.continue, true);
+    assert.ok(typeof parsed.additionalContext === 'string');
+    assert.ok(parsed.additionalContext.includes('injected decision'));
+    assert.strictEqual(parsed.hookSpecificOutput?.hookEventName, 'SessionStart');
+    assert.ok(parsed.hookSpecificOutput?.additionalContext?.includes('no db in hooks'));
+  });
+
+  it('should not inject on resume', () => {
+    const out = runHook('on-session-start', {
+      hook_event_name: 'SessionStart',
+      source: 'resume',
+      cwd: testProjectPath,
+      session_id: 's-resume-1',
+    });
+    const parsed = JSON.parse(out.trim());
+    assert.strictEqual(parsed.continue, true);
+    assert.strictEqual(parsed.additionalContext, undefined);
+    assert.strictEqual(parsed.hookSpecificOutput, undefined);
+  });
+
+  it('should continue without context when snapshot is missing', () => {
+    const emptyPath = join(tmpdir(), `sqlew-empty-${Date.now()}`);
+    mkdirSync(join(emptyPath, '.sqlew'), { recursive: true });
+
+    const out = runHook('on-session-start', {
+      hook_event_name: 'SessionStart',
+      source: 'startup',
+      cwd: emptyPath,
+      session_id: 's-empty-1',
+    });
+    const parsed = JSON.parse(out.trim());
+    assert.strictEqual(parsed.continue, true);
+    assert.strictEqual(parsed.additionalContext, undefined);
+
+    rmSync(emptyPath, { recursive: true, force: true });
+  });
+
+  it('should inject on clear source (coexists with plan rescue)', () => {
+    const out = runHook('on-session-start', {
+      hook_event_name: 'SessionStart',
+      source: 'clear',
+      cwd: testProjectPath,
+      session_id: 's-clear-1',
+    });
+    const parsed = JSON.parse(out.trim());
+    assert.strictEqual(parsed.continue, true);
+    assert.ok(parsed.additionalContext?.includes('sqlew'));
+  });
+});

--- a/src/tests/unit/config/hooks-config.test.ts
+++ b/src/tests/unit/config/hooks-config.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Hooks configuration unit tests
+ *
+ * @since v5.4.0
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { writeFileSync, unlinkSync, mkdirSync, existsSync } from 'fs';
+import { join } from 'path';
+import { loadConfigFile, validateConfig } from '../../../config/loader.js';
+import { DEFAULT_CONFIG, DEFAULT_SESSION_CONTEXT_BUDGET } from '../../../config/types.js';
+
+const TEST_DIR = join(process.cwd(), '.sqlew-test-hooks');
+const TEST_CONFIG_PATH = join(TEST_DIR, 'config.toml');
+
+describe('hooks-config', () => {
+  before(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  after(() => {
+    if (existsSync(TEST_CONFIG_PATH)) {
+      unlinkSync(TEST_CONFIG_PATH);
+    }
+  });
+
+  describe('loadConfigFile', () => {
+    it('should merge [hooks] section with defaults', () => {
+      writeFileSync(
+        TEST_CONFIG_PATH,
+        `[hooks]\nsession_context_budget = 250\n`,
+        'utf-8',
+      );
+      const config = loadConfigFile(TEST_DIR, 'config.toml');
+      assert.strictEqual(config.hooks?.session_context_budget, 250);
+    });
+
+    it('should apply default session_context_budget when [hooks] is absent', () => {
+      writeFileSync(TEST_CONFIG_PATH, `[database]\npath = ".sqlew/test.db"\n`, 'utf-8');
+      const config = loadConfigFile(TEST_DIR, 'config.toml');
+      assert.strictEqual(
+        config.hooks?.session_context_budget,
+        DEFAULT_SESSION_CONTEXT_BUDGET,
+      );
+    });
+  });
+
+  describe('validateConfig', () => {
+    it('should accept budget 0 (disabled)', () => {
+      const result = validateConfig({
+        ...DEFAULT_CONFIG,
+        hooks: { session_context_budget: 0 },
+      });
+      assert.strictEqual(result.valid, true);
+    });
+
+    it('should accept default budget 500', () => {
+      const result = validateConfig({
+        ...DEFAULT_CONFIG,
+        hooks: { session_context_budget: 500 },
+      });
+      assert.strictEqual(result.valid, true);
+    });
+
+    it('should reject budget -1', () => {
+      const result = validateConfig({
+        ...DEFAULT_CONFIG,
+        hooks: { session_context_budget: -1 },
+      });
+      assert.strictEqual(result.valid, false);
+      assert.ok(result.errors.some(e => e.includes('session_context_budget')));
+    });
+
+    it('should reject budget 10001', () => {
+      const result = validateConfig({
+        ...DEFAULT_CONFIG,
+        hooks: { session_context_budget: 10001 },
+      });
+      assert.strictEqual(result.valid, false);
+      assert.ok(result.errors.some(e => e.includes('session_context_budget')));
+    });
+
+    it('should reject non-integer budget', () => {
+      const result = validateConfig({
+        ...DEFAULT_CONFIG,
+        hooks: { session_context_budget: 250.5 },
+      });
+      assert.strictEqual(result.valid, false);
+    });
+  });
+});

--- a/src/tests/unit/hooks/session-context.test.ts
+++ b/src/tests/unit/hooks/session-context.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Session context hook helpers unit tests
+ *
+ * @since v5.4.0
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  formatContextBlock,
+  loadSnapshot,
+  shouldInjectOnPrompt,
+} from '../../../cli/hooks/session-context.js';
+import { saveSessionContextMarker } from '../../../config/global-config.js';
+import {
+  SESSION_SNAPSHOT_VERSION,
+  writeSessionSnapshot,
+  type SessionSnapshot,
+} from '../../../utils/session-snapshot.js';
+
+let testProjectPath: string;
+
+function makeSnapshot(overrides: Partial<SessionSnapshot> = {}): SessionSnapshot {
+  return {
+    version: SESSION_SNAPSHOT_VERSION,
+    project_name: 'test',
+    generated_at: new Date().toISOString(),
+    decisions: [{ key: 'test/key', value: 'test value', updated: '2026-07-02' }],
+    constraints: [{ category: 'architecture', rule: 'no views', priority: 'high' }],
+    ...overrides,
+  };
+}
+
+describe('session-context helpers', () => {
+  beforeEach(() => {
+    testProjectPath = join(tmpdir(), `sqlew-ctx-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(join(testProjectPath, '.sqlew'), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testProjectPath)) {
+      rmSync(testProjectPath, { recursive: true, force: true });
+    }
+  });
+
+  describe('formatContextBlock', () => {
+    it('should return null for budget 0', () => {
+      assert.strictEqual(formatContextBlock(makeSnapshot(), 0), null);
+    });
+
+    it('should return null when both lists are empty', () => {
+      assert.strictEqual(
+        formatContextBlock(makeSnapshot({ decisions: [], constraints: [] }), 500),
+        null,
+      );
+    });
+
+    it('should format constraints before decisions', () => {
+      const block = formatContextBlock(makeSnapshot(), 500);
+      assert.ok(block);
+      const constraintPos = block!.indexOf('Active Constraints');
+      const decisionPos = block!.indexOf('Recent Decisions');
+      assert.ok(constraintPos < decisionPos);
+    });
+
+    it('should trim content exceeding budget', () => {
+      const manyDecisions = Array.from({ length: 50 }, (_, i) => ({
+        key: `key/${i}`,
+        value: 'x'.repeat(100),
+        updated: '2026-07-02',
+      }));
+      const block = formatContextBlock(makeSnapshot({ decisions: manyDecisions }), 50);
+      assert.ok(block);
+      assert.ok(block!.length < manyDecisions.length * 100);
+    });
+  });
+
+  describe('loadSnapshot', () => {
+    it('should return null when file is missing', async () => {
+      assert.strictEqual(await loadSnapshot(testProjectPath), null);
+    });
+
+    it('should return null for version mismatch', async () => {
+      writeSessionSnapshot(testProjectPath, {
+        ...makeSnapshot(),
+        version: 99 as typeof SESSION_SNAPSHOT_VERSION,
+      });
+      assert.strictEqual(await loadSnapshot(testProjectPath), null);
+    });
+
+    it('should return null for stale snapshot (>30 days)', async () => {
+      const stale = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000).toISOString();
+      writeSessionSnapshot(testProjectPath, makeSnapshot({ generated_at: stale }));
+      assert.strictEqual(await loadSnapshot(testProjectPath), null);
+    });
+
+    it('should return null for corrupt JSON', async () => {
+      writeFileSync(
+        join(testProjectPath, '.sqlew', 'session-context.json'),
+        '{not valid json',
+        'utf-8',
+      );
+      assert.strictEqual(await loadSnapshot(testProjectPath), null);
+    });
+
+    it('should load valid snapshot', async () => {
+      writeSessionSnapshot(testProjectPath, makeSnapshot());
+      const loaded = await loadSnapshot(testProjectPath);
+      assert.ok(loaded);
+      assert.strictEqual(loaded!.project_name, 'test');
+    });
+  });
+
+  describe('shouldInjectOnPrompt', () => {
+    it('should return false when session_id is missing', () => {
+      assert.strictEqual(shouldInjectOnPrompt(testProjectPath, undefined), false);
+    });
+
+    it('should return true for new session_id', () => {
+      saveSessionContextMarker(testProjectPath, {
+        session_id: 'old-session',
+        injected_at: new Date().toISOString(),
+        harness: 'hermes',
+      });
+      assert.strictEqual(shouldInjectOnPrompt(testProjectPath, 'new-session'), true);
+    });
+
+    it('should return false for same session_id', () => {
+      saveSessionContextMarker(testProjectPath, {
+        session_id: 'same-session',
+        injected_at: new Date().toISOString(),
+        harness: 'codex',
+      });
+      assert.strictEqual(shouldInjectOnPrompt(testProjectPath, 'same-session'), false);
+    });
+  });
+});

--- a/src/tools/constraints/actions/activate.ts
+++ b/src/tools/constraints/actions/activate.ts
@@ -13,6 +13,7 @@ import { getProjectContext } from '../../../utils/project-context.js';
 import { normalizeParams, CONSTRAINT_ALIASES } from '../../../utils/param-normalizer.js';
 import connectionManager from '../../../utils/connection-manager.js';
 import { SQLITE_TRUE } from '../../../constants.js';
+import { scheduleSnapshotRefresh } from '../../../utils/session-snapshot.js';
 
 /**
  * Activate constraints by tag response
@@ -72,6 +73,7 @@ export async function activateConstraintsByTag(
         .where('project_id', projectId)
         .update({ active: SQLITE_TRUE });
 
+      scheduleSnapshotRefresh();
       return {
         success: true,
         activated_count: constraintIds.length,
@@ -128,6 +130,7 @@ export async function activateConstraint(
         .where('project_id', projectId)
         .update({ active: SQLITE_TRUE });
 
+      scheduleSnapshotRefresh();
       return {
         success: true,
         id: normalizedParams.id,

--- a/src/tools/constraints/actions/add.ts
+++ b/src/tools/constraints/actions/add.ts
@@ -22,6 +22,7 @@ import { normalizeParams, CONSTRAINT_ALIASES } from '../../../utils/param-normal
 import { parseStringArray } from '../../../utils/param-parser.js';
 import { getProjectContext } from '../../../utils/project-context.js';
 import { ftsInsertConstraint } from '../../../utils/fts.js';
+import { scheduleSnapshotRefresh } from '../../../utils/session-snapshot.js';
 import connectionManager from '../../../utils/connection-manager.js';
 import type {
   AddConstraintParams,
@@ -131,6 +132,7 @@ export async function addConstraint(
         return { constraintId: Number(constraintId), alreadyExists: false };
       });
 
+      scheduleSnapshotRefresh();
       return {
         success: true,
         constraint_id: result.constraintId,

--- a/src/tools/constraints/actions/deactivate.ts
+++ b/src/tools/constraints/actions/deactivate.ts
@@ -10,6 +10,7 @@ import { normalizeParams, CONSTRAINT_ALIASES } from '../../../utils/param-normal
 import { getProjectContext } from '../../../utils/project-context.js';
 import connectionManager from '../../../utils/connection-manager.js';
 import { SQLITE_FALSE } from '../../../constants.js';
+import { scheduleSnapshotRefresh } from '../../../utils/session-snapshot.js';
 import type {
   DeactivateConstraintParams,
   DeactivateConstraintResponse
@@ -56,6 +57,7 @@ export async function deactivateConstraint(
         .where({ id: normalizedParams.id, project_id: projectId })
         .update({ active: SQLITE_FALSE });
 
+      scheduleSnapshotRefresh();
       return {
         success: true,
       };

--- a/src/tools/context/actions/hard-delete.ts
+++ b/src/tools/context/actions/hard-delete.ts
@@ -11,6 +11,7 @@ import { getAdapter } from '../../../database.js';
 import { getProjectContext } from '../../../utils/project-context.js';
 import connectionManager from '../../../utils/connection-manager.js';
 import { ftsDeleteDecision } from '../../../utils/fts.js';
+import { scheduleSnapshotRefresh } from '../../../utils/session-snapshot.js';
 import { validateActionParams } from '../internal/validation.js';
 import type { HardDeleteDecisionParams, HardDeleteDecisionResponse } from '../types.js';
 
@@ -35,7 +36,7 @@ export async function hardDeleteDecision(
   const projectId = getProjectContext().getProjectId();
 
   try {
-    return await connectionManager.executeWithRetry(async () => {
+    const result = await connectionManager.executeWithRetry(async () => {
       return await actualAdapter.transaction(async (trx) => {
         // Get key_id
         const keyResult = await trx('m_context_keys')
@@ -100,6 +101,8 @@ export async function hardDeleteDecision(
         };
       });
     });
+    scheduleSnapshotRefresh();
+    return result;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to hard delete decision: ${message}`);

--- a/src/tools/context/internal/queries.ts
+++ b/src/tools/context/internal/queries.ts
@@ -15,6 +15,7 @@ import { parseStringArray } from '../../../utils/param-parser.js';
 import { incrementSemver, isValidSemver } from '../../../utils/semver.js';
 import { validateAgainstPolicies } from '../../../utils/policy-validator.js';
 import { ftsUpsertDecision } from '../../../utils/fts.js';
+import { scheduleSnapshotRefresh } from '../../../utils/session-snapshot.js';
 import { handleSuggestAction } from '../../suggest/index.js';
 import { constraintByContext } from '../../suggest/actions/constraint-by-context.js';
 import type { SetDecisionParams, SetDecisionResponse } from '../types.js';
@@ -749,6 +750,7 @@ export async function setDecisionInternal(
     keyName: params.key,
     value: String(value),
   });
+  scheduleSnapshotRefresh();
 
   // Build response object
   const response: SetDecisionResponse = {

--- a/src/utils/session-snapshot.ts
+++ b/src/utils/session-snapshot.ts
@@ -1,0 +1,368 @@
+/**
+ * Session context snapshot writer
+ *
+ * MCP server writes top-N decisions + active constraints to
+ * .sqlew/session-context.json. Hooks read this file without opening the DB.
+ *
+ * Fail-soft: snapshot failures never fail the primary write operation.
+ *
+ * @since v5.4.0
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync, renameSync } from 'fs';
+import { join } from 'path';
+import type { Knex } from 'knex';
+import { getAdapter } from '../database.js';
+import { isCloudMode } from '../backend/backend-factory.js';
+import { loadConfigWithWorktreeSupport } from '../config/loader.js';
+import {
+  DEFAULT_SESSION_CONTEXT_BUDGET,
+} from '../config/types.js';
+import { DEFAULT_STATUS } from '../constants.js';
+import { getProjectContext } from './project-context.js';
+import { UniversalKnex } from './universal-knex.js';
+import { convertPriorityArray } from './enum-converter.js';
+import { debugLog } from './debug-logger.js';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+export const SESSION_SNAPSHOT_VERSION = 1 as const;
+export const SESSION_SNAPSHOT_FILENAME = 'session-context.json';
+export const MAX_SNAPSHOT_DECISIONS = 15;
+export const MAX_SNAPSHOT_CONSTRAINTS = 15;
+export const VALUE_TRUNCATE_CHARS = 200;
+export const REASON_TRUNCATE_CHARS = 150;
+const DEBOUNCE_MS = 500;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface SnapshotDecision {
+  key: string;
+  value: string;
+  layer?: string;
+  tags?: string;
+  updated: string;
+}
+
+export interface SnapshotConstraint {
+  category: string;
+  rule: string;
+  priority: string;
+  reason?: string;
+  tags?: string;
+}
+
+export interface SessionSnapshot {
+  version: typeof SESSION_SNAPSHOT_VERSION;
+  project_name: string;
+  generated_at: string;
+  decisions: SnapshotDecision[];
+  constraints: SnapshotConstraint[];
+}
+
+interface PendingRefresh {
+  projectId: number;
+  projectName: string;
+  rootPath: string;
+}
+
+// ============================================================================
+// State
+// ============================================================================
+
+const pendingRefreshes = new Map<number, PendingRefresh>();
+const debounceTimers = new Map<number, ReturnType<typeof setTimeout>>();
+
+// ============================================================================
+// Path helpers
+// ============================================================================
+
+export function getSnapshotPath(rootPath: string): string {
+  return join(rootPath, '.sqlew', SESSION_SNAPSHOT_FILENAME);
+}
+
+function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+  return text.slice(0, maxChars - 3) + '...';
+}
+
+// ============================================================================
+// Snapshot building
+// ============================================================================
+
+export async function buildSessionSnapshot(
+  knex: Knex,
+  projectId: number,
+  projectName: string,
+): Promise<SessionSnapshot> {
+  const db = new UniversalKnex(knex);
+
+  const castNumericToText = db.isPostgreSQL
+    ? 'CAST(dn.value AS TEXT)'
+    : db.isSQLite
+      ? 'dn.value'
+      : 'CAST(dn.value AS CHAR)';
+
+  const decisionRows = await knex('t_decisions as d')
+    .join('m_context_keys as k', 'd.key_id', 'k.id')
+    .leftJoin('m_layers as l', 'd.layer_id', 'l.id')
+    .leftJoin('t_decisions_numeric as dn', function () {
+      this.on('dn.key_id', '=', 'd.key_id').andOn('dn.project_id', '=', 'd.project_id');
+    })
+    .where('d.project_id', projectId)
+    .where('d.status', DEFAULT_STATUS)
+    .orderBy('d.ts', 'desc')
+    .limit(MAX_SNAPSHOT_DECISIONS)
+    .select([
+      'k.key_name as key',
+      knex.raw(`COALESCE(NULLIF(d.value, ''), ${castNumericToText}) as value`),
+      'l.name as layer',
+      knex.raw(`${db.dateFunction('d.ts')} as updated`),
+      knex.raw(`(
+        SELECT ${db.stringAgg('t2.name', ',')}
+        FROM t_decision_tags dt2
+        JOIN m_tags t2 ON dt2.tag_id = t2.id
+        WHERE dt2.decision_key_id = d.key_id
+      ) as tags`),
+    ]);
+
+  const constraintRows = await knex('t_constraints as c')
+    .join('m_constraint_categories as cat', 'c.category_id', 'cat.id')
+    .where('c.project_id', projectId)
+    .where('c.active', db.boolTrue())
+    .orderBy('c.priority', 'desc')
+    .orderBy('c.ts', 'desc')
+    .limit(MAX_SNAPSHOT_CONSTRAINTS)
+    .select([
+      'cat.name as category',
+      'c.constraint_text',
+      'c.reason',
+      'c.priority',
+      knex.raw(`(
+        SELECT ${db.stringAgg('t2.name', ',')}
+        FROM t_constraint_tags ct2
+        JOIN m_tags t2 ON ct2.tag_id = t2.id
+        WHERE ct2.constraint_id = c.id
+      ) as tags`),
+    ]);
+
+  const priorityRows = convertPriorityArray(constraintRows);
+
+  const decisions: SnapshotDecision[] = decisionRows.map((row: Record<string, unknown>) => ({
+    key: String(row.key),
+    value: truncateText(String(row.value ?? ''), VALUE_TRUNCATE_CHARS),
+    ...(row.layer ? { layer: String(row.layer) } : {}),
+    ...(row.tags ? { tags: String(row.tags) } : {}),
+    updated: String(row.updated),
+  }));
+
+  const constraints: SnapshotConstraint[] = priorityRows.map((row: Record<string, unknown>) => ({
+    category: String(row.category),
+    rule: truncateText(String(row.constraint_text ?? ''), VALUE_TRUNCATE_CHARS),
+    priority: String(row.priority),
+    ...(row.reason ? { reason: truncateText(String(row.reason), REASON_TRUNCATE_CHARS) } : {}),
+    ...(row.tags ? { tags: String(row.tags) } : {}),
+  }));
+
+  return {
+    version: SESSION_SNAPSHOT_VERSION,
+    project_name: projectName,
+    generated_at: new Date().toISOString(),
+    decisions,
+    constraints,
+  };
+}
+
+// ============================================================================
+// Snapshot writing
+// ============================================================================
+
+export function writeSessionSnapshot(rootPath: string, snapshot: SessionSnapshot): void {
+  const snapshotPath = getSnapshotPath(rootPath);
+  const sqlewDir = join(rootPath, '.sqlew');
+
+  if (!existsSync(sqlewDir)) {
+    mkdirSync(sqlewDir, { recursive: true });
+  }
+
+  const tempPath = snapshotPath + '.tmp';
+  const content = JSON.stringify(snapshot, null, 2);
+  writeFileSync(tempPath, content, 'utf-8');
+
+  try {
+    renameSync(tempPath, snapshotPath);
+  } catch (error) {
+    debugLog('WARN', '[session-snapshot] rename failed, using direct write', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    writeFileSync(snapshotPath, content, 'utf-8');
+    try {
+      unlinkSync(tempPath);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+export function readSessionSnapshot(rootPath: string): SessionSnapshot | null {
+  const snapshotPath = getSnapshotPath(rootPath);
+  if (!existsSync(snapshotPath)) {
+    return null;
+  }
+  try {
+    return JSON.parse(readFileSync(snapshotPath, 'utf-8')) as SessionSnapshot;
+  } catch {
+    return null;
+  }
+}
+
+// ============================================================================
+// Refresh scheduling
+// ============================================================================
+
+async function isSnapshotEnabled(rootPath: string): Promise<boolean> {
+  try {
+    const config = await loadConfigWithWorktreeSupport(rootPath);
+    if (isCloudMode(config)) {
+      return false;
+    }
+    const budget = config.hooks?.session_context_budget ?? DEFAULT_SESSION_CONTEXT_BUDGET;
+    return budget > 0;
+  } catch (error) {
+    debugLog('WARN', '[session-snapshot] config load failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}
+
+async function executeRefresh(pending: PendingRefresh): Promise<void> {
+  try {
+    if (!(await isSnapshotEnabled(pending.rootPath))) {
+      return;
+    }
+
+    const adapter = getAdapter();
+    const knex = adapter.getKnex();
+    const snapshot = await buildSessionSnapshot(
+      knex,
+      pending.projectId,
+      pending.projectName,
+    );
+    writeSessionSnapshot(pending.rootPath, snapshot);
+    debugLog('DEBUG', '[session-snapshot] refreshed', {
+      projectId: pending.projectId,
+      decisions: snapshot.decisions.length,
+      constraints: snapshot.constraints.length,
+    });
+  } catch (error) {
+    debugLog('WARN', '[session-snapshot] refresh failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
+ * Schedule a debounced snapshot refresh for the current project.
+ * Captures project metadata at call time (ALS-safe).
+ */
+export function scheduleSnapshotRefresh(): void {
+  try {
+    const ctx = getProjectContext();
+    if (ctx.isUnbound()) {
+      return;
+    }
+
+    let metadata;
+    try {
+      metadata = ctx.getProjectMetadata();
+    } catch {
+      return;
+    }
+
+    const rootPath = metadata.project_root_path;
+    if (!rootPath) {
+      return;
+    }
+
+    const pending: PendingRefresh = {
+      projectId: metadata.id,
+      projectName: metadata.name,
+      rootPath,
+    };
+
+    pendingRefreshes.set(metadata.id, pending);
+
+    const existing = debounceTimers.get(metadata.id);
+    if (existing) {
+      clearTimeout(existing);
+    }
+
+    const timer = setTimeout(() => {
+      debounceTimers.delete(metadata.id);
+      const latest = pendingRefreshes.get(metadata.id);
+      if (latest) {
+        void executeRefresh(latest);
+      }
+    }, DEBOUNCE_MS);
+
+    if (typeof timer.unref === 'function') {
+      timer.unref();
+    }
+
+    debounceTimers.set(metadata.id, timer);
+  } catch (error) {
+    debugLog('WARN', '[session-snapshot] schedule failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
+ * Immediately refresh the session snapshot for the current project.
+ * Used at server startup.
+ */
+export async function refreshSnapshotNow(): Promise<void> {
+  try {
+    const ctx = getProjectContext();
+    if (ctx.isUnbound()) {
+      return;
+    }
+
+    const metadata = ctx.getProjectMetadata();
+    const rootPath = metadata.project_root_path;
+    if (!rootPath) {
+      return;
+    }
+
+    await executeRefresh({
+      projectId: metadata.id,
+      projectName: metadata.name,
+      rootPath,
+    });
+  } catch (error) {
+    debugLog('WARN', '[session-snapshot] refreshSnapshotNow failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
+ * Flush pending debounced refreshes (for tests).
+ */
+export async function flushSnapshotRefresh(): Promise<void> {
+  for (const [projectId, timer] of debounceTimers) {
+    clearTimeout(timer);
+    debounceTimers.delete(projectId);
+    const pending = pendingRefreshes.get(projectId);
+    if (pending) {
+      await executeRefresh(pending);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Inject recent decisions and active constraints at session start via a fail-soft `.sqlew/session-context.json` snapshot (MCP writes, hooks read only).
- Add `[hooks] session_context_budget` config (default 500 tokens; `0` disables).
- Deliver context on Claude `SessionStart`, Hermes first `pre_llm_call`, and Codex `SessionStart` / `UserPromptSubmit` fallback with session dedup markers.
- Add user-facing [HARNESS_COMPATIBILITY.md](docs/HARNESS_COMPATIBILITY.md) matrix and Auto-ADR how-to guide.

## Architecture Decisions

### Decision: Snapshot file architecture (hooks must not open DB; avoids migration races with concurrent MCP server)

- `src/utils/session-snapshot.ts`: builds top-N decisions/constraints snapshot and write-through refresh on MCP writes and server startup.
- `src/cli/hooks/session-context.ts`: reads snapshot and formats injection payload; session-cache dedup markers.
- `src/cli/hooks/on-session-start.ts`: Claude/Codex SessionStart injection via `sendSessionStartContext`.
- `src/cli/hooks/on-prompt.ts`: Hermes/Codex fallback injection combined with plan guidance.
- `src/tools/context/internal/queries.ts`, `src/tools/constraints/actions/*.ts`, `src/tools/context/actions/hard-delete.ts`: trigger snapshot refresh after writes.
- `src/server/setup.ts`: `refreshSnapshotNow()` on MCP server startup.

### Decision: Multi-harness delivery matrix (per-client hook capabilities differ; Grok passive hooks unsupported)

- `src/cli/hooks/stdin-parser.ts`: `sendSessionStartContext` and client-specific output shapes.
- `src/cli/hooks/on-session-start.ts`: skip resume/compact sources; startup/clear only for Claude.
- `src/cli/hooks/on-prompt.ts`: Hermes `pre_llm_call` JSON context line; Codex plain-text fallback.
- `src/config/global-config.ts`: `*.context.json` sidecar markers under `session-cache/`.

### Decision: session_context_budget default enabled (opt-out via `0`, not opt-in)

- `src/config/types.ts`, `src/config/loader.ts`, `src/config/global-config.ts`: `[hooks] session_context_budget` with first-config-wins precedence.
- `docs/CONFIGURATION.md`, `docs/HOOKS_GUIDE.md`: document config and architecture.

### Constraint: Fail-soft snapshot writes (snapshot failure must not fail primary MCP operations)

- `src/utils/session-snapshot.ts`: errors logged; callers swallow failures on refresh paths.

## Other Changes

- `docs/HARNESS_COMPATIBILITY.md`: feature × harness matrix, user-facing Auto-ADR guide (`approve` terminology, **Other harness** column).
- `README.md`, `CHANGELOG.md`, `docs/HERMES_HOOKS.md`: compatibility links and v5.4.0 unreleased notes.
- `src/init-rules.ts`, `.gitignore`: ignore `.sqlew/session-context.json`.
- `src/tests/feature/session-snapshot/`, `src/tests/integration/session-start-injection.test.ts`, `src/tests/unit/hooks/session-context.test.ts`, `src/tests/unit/config/hooks-config.test.ts`, `src/tests/integration/hermes-on-prompt.test.ts`: coverage for snapshot, injection, and config.

## Test Plan

- [x] `npm run build`
- [x] `npm test` (pre-commit hook)
- [x] Claude Code: restart MCP → confirm `.sqlew/session-context.json` and SessionStart injection
- [x] Hermes: first prompt receives session context via `pre_llm_call`
- [x] Codex: SessionStart or first UserPromptSubmit fallback with dedup
- [x] Grok Build: confirm no injection (documented limitation)