### PR TITLE
fix(grok): multi-trigger plan.md template injection and exit gate (v5.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,31 @@ Proactively injects recent decisions and active constraints at session start so 
 
 ### Limitations
 
-- **Grok Build** — Passive hooks ignore stdout; session context injection is not available in v5.4. Use skills or `/sqlew search` manually.
+- **Grok Build** — Passive hooks ignore stdout; session context injection is not available in v5.4. Use skills or `/sqlew search` manually. Plan template uses multi-trigger file injection (v5.3.3).
+
+---
+
+## [5.3.3] - 2026-07-11
+
+### Fixed
+
+**Grok Build Plan-to-ADR: multi-trigger plan.md template + exit gate**
+
+Grok passive hooks ignore stdout, so Decision/Constraint sections must land on disk. `enter_plan_mode`-only injection was too narrow (`/plan` never fired; full-file writes wiped the template).
+
+- **Multi-trigger file injection** — `injectGrokPlanTemplate` / `ensureGrokPlanTemplate` (`src/cli/hooks/grok-plan-template.ts`):
+  1. `enter_plan_mode` PreToolUse (`track-plan`)
+  2. `UserPromptSubmit` when session `plan_mode.json` is Active/Pending (`on-prompt`, side-effect only)
+  3. PostToolUse on Grok `plan.md` edits (`track-plan` re-append if marker/patterns missing)
+- **Helpers** — `computeGrokSessionDir`, `readGrokPlanModeState`, `isGrokPlanFile`; `GROK_TOOL_MAP` maps `write` → `Write`
+- **Exit gate** — PreToolUse `exit_plan_mode` denies when `hooks.grok_require_patterns` is true (default) and `plan.md` has no **filled** 📌/🚫 (`hasFilledPatterns`; template placeholders do not count). Escape: Value/Rule `N/A`, or `grok_require_patterns = false`
+- **Config** — `[hooks] grok_require_patterns` (boolean, default `true`)
+
+Pair with [sqlew-plugin 5.3.2](https://github.com/sqlew-io/sqlew-plugin) for expanded hook matchers (`write` / `search_replace` / `ExitPlanMode` PreToolUse + PostToolUse `track-plan`).
+
+### Documentation
+
+- **HOOKS_GUIDE / HARNESS_COMPATIBILITY / CONFIGURATION** — Grok multi-trigger injection, exit gate, `grok_require_patterns`
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -86,11 +86,13 @@ Authentication, encryption, and scaling are managed by the sqlew cloud service �
 ```toml
 [hooks]
 session_context_budget = 500   # Token budget for session-start context injection (default: 500)
+grok_require_patterns = true   # Grok: deny exit_plan_mode without filled 📌/🚫 (default: true)
 ```
 
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `session_context_budget` | `500` | Estimated token budget for injected session context. Set to `0` to disable both injection and snapshot writes. Valid range: `0`–`10000` (integer). |
+| `grok_require_patterns` | `true` | Grok Build only. When `true`, PreToolUse on `exit_plan_mode` **denies** approval if `plan.md` has no filled `### 📌 Decision:` / `### 🚫 Constraint:` blocks (template placeholders alone do not count). Set `Value`/`Rule` to `N/A` if nothing to record, or set this to `false` to disable the gate. |
 
 **Priority:** Config loading uses first-match-wins (local `.sqlew/config.toml` > worktree parent > global `~/.config/sqlew/config.toml` > defaults). There is no deep merge — if a local config file exists, global `[hooks]` settings are not applied.
 

--- a/docs/HARNESS_COMPATIBILITY.md
+++ b/docs/HARNESS_COMPATIBILITY.md
@@ -24,7 +24,7 @@ Minimum sqlew versions: Grok Build **5.2+**, Codex **5.2.1+**, Hermes **5.3.0+**
 |---------|:-----------:|:-----:|:----------:|:------:|:--------------:|
 | **MCP tools** (`decision`, `constraint`, `suggest`, `project`, `queue`, …) | ✓ | ✓ | ✓ | ✓ | ✓ |
 | **Session context injection** (recent decisions + active constraints at session start) | ✓ | △ | — | ✓ | ✎ |
-| **Plan mode enforcement** (suggest-before-plan, 📌/🚫 format) | ✓ | △ | ◎ | ✓ | ✎ |
+| **Plan mode enforcement** (suggest-before-plan, 📌/🚫 format) | ✓ | △ | ◎+file | ✓ | ✎ |
 | **Plan-to-ADR extraction** (📌 Decision / 🚫 Constraint → DB) | ✓ | △ | △ | △ | ✎ |
 | **Plan file tracking** (`track-plan`) | ✓ | ✓ | ✓ | ✓ | — |
 | **Decision draft on code edit** (`save` hook) | ✓ | ✓ | ✓ | ✓ | — |
@@ -81,7 +81,7 @@ Most hooks work after trusting bundled hooks (`/hooks`). Plan mode needs `collab
 
 ### Grok Build
 
-**Passive hooks:** stdout from hooks is ignored except deny JSON on `pre_tool_use`. Plan guidance and decision format come from **skills** (◎). Plan-to-ADR reads `plan.md` when you **approve the plan**. Do not duplicate hooks in `~/.grok/hooks/`.
+**Passive hooks:** stdout from hooks is ignored except deny JSON on `pre_tool_use`. Plan **format** guidance comes from **skills** (◎). The 📌/🚫 **template block** is maintained on disk in `plan.md` via multi-trigger file injection (`enter_plan_mode`, plan-mode `UserPromptSubmit`, PostToolUse re-inject after overwrites). **Exit gate:** `exit_plan_mode` is denied when `hooks.grok_require_patterns` is true (default) and the plan has no filled 📌/🚫 (template placeholders alone fail). Plan-to-ADR reads `plan.md` when you **approve the plan**. Do not duplicate hooks in `~/.grok/hooks/`.
 
 ### Hermes
 

--- a/docs/HOOKS_GUIDE.md
+++ b/docs/HOOKS_GUIDE.md
@@ -94,7 +94,11 @@ grok inspect              # hooks, MCP, skills visible
 **Important**:
 - Do NOT register sqlew hooks in `~/.grok/hooks/` (causes double-firing with plugin hooks)
 - Do NOT add `[mcp_servers.sqlew]` to `~/.grok/config.toml` (plugin `.mcp.json` handles MCP)
-- Plan mode guidance uses plugin skills (`sqlew-plan-guidance`, `sqlew-decision-format`), not hook injection
+- Plan guidance **format** uses plugin skills (`sqlew-plan-guidance`, `sqlew-decision-format`); Grok ignores hook **stdout**, so format reminders are not injected via `UserPromptSubmit`
+- Decision/Constraint **template sections** are seeded on `plan.md` via file side-effects (not stdout):
+  1. `enter_plan_mode` PreToolUse → `track-plan` creates/appends template
+  2. `UserPromptSubmit` when session `plan_mode.json` is Active/Pending → `on-prompt` ensures template (covers `/plan` without `enter_plan_mode`)
+  3. PostToolUse on `plan.md` write/edit → `track-plan` re-appends if the agent overwrote the template
 - Plan-to-ADR extracts `### 📌 Decision:` / `### 🚫 Constraint:` from `plan.md` on `exit_plan_mode`
 
 Source: https://github.com/sqlew-io/sqlew-plugin
@@ -161,6 +165,10 @@ See [CONFIGURATION.md](CONFIGURATION.md) for priority rules (local config overri
 ### Grok Build limitation
 
 Grok Build hooks are passive — stdout injection is ignored. Session context injection is not available in v5.4. Use `/sqlew search` or the `sqlew-plan-guidance` skill to recall context manually.
+
+**Plan template file injection (v5.5+):** Because stdout cannot carry plan enforcement, sqlew writes the 📌/🚫 template block directly into `~/.grok/sessions/<encoded-cwd>/<sessionId>/plan.md`. Triggers: `enter_plan_mode`, `UserPromptSubmit` while plan mode is Active/Pending (`plan_mode.json`), and PostToolUse after plan.md edits (re-inject if wiped). Skip when the marker or real patterns already exist.
+
+**Exit gate (v5.5+):** PreToolUse on `exit_plan_mode` denies approval when `hooks.grok_require_patterns` is true (default) and `plan.md` has no **filled** Decision/Constraint blocks (placeholders from the auto-template do not count). Fill real 📌/🚫 values, or set Value/Rule to `N/A`, or disable with `grok_require_patterns = false`.
 
 ## Version History
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "sqlew",
   "display_name": "sqlew - Context Manager for AI Agents",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "description": "Token-efficient context management for AI coding agents. Record architectural decisions, constraints, and maintain project knowledge across sessions. Supports SQLite local storage and sqlew.io cloud backend.",
   "author": {
     "name": "sqlew.io",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlew",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlew",
-      "version": "5.3.2",
+      "version": "5.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.21.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sqlew",
   "description": "Automated ADR (Architecture Decision Records) for AI Coding Agents - MCP server with SQL-backed decision repository",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "main": "dist/index.js",
   "type": "module",
   "bin": {

--- a/src/cli/hooks/grok-plan-template.ts
+++ b/src/cli/hooks/grok-plan-template.ts
@@ -1,0 +1,117 @@
+/**
+ * Grok Build plan.md Decision/Constraint template injection.
+ *
+ * Grok passive hooks ignore stdout, so templates are written directly to
+ * ~/.grok/sessions/.../plan.md (file side-effect). Used by:
+ * - enter_plan_mode (track-plan)
+ * - UserPromptSubmit when plan_mode is Active/Pending (on-prompt)
+ * - PostToolUse re-inject after plan.md overwrites (track-plan)
+ *
+ * Kept separate from track-plan / on-prompt to avoid circular imports.
+ *
+ * @since v5.2.0 (logic lived in track-plan.ts)
+ * @modified v5.5.x - extracted module + ensureGrokPlanTemplate multi-trigger
+ */
+
+import { randomUUID } from 'crypto';
+import { existsSync, readFileSync, writeFileSync, appendFileSync, mkdirSync } from 'fs';
+import { dirname } from 'path';
+import { computeGrokPlanPath } from './stdin-parser.js';
+import {
+  saveCurrentPlan,
+  loadCurrentPlan,
+  type CurrentPlanInfo,
+} from '../../config/global-config.js';
+import { hasPatterns } from './plan-pattern-extractor.js';
+import { debugLog } from '../../utils/debug-logger.js';
+
+/**
+ * Decision/Constraint template to inject on new plan creation
+ * Compact format for context window efficiency
+ */
+const PLAN_TEMPLATE = `
+---
+## 📝 Decision/Constraint Recording (auto-detected on ExitPlanMode)
+
+### 📌 Decision: [key/path]
+- **Value**: Description
+- **Layer**: presentation | business | data | infrastructure | cross-cutting
+- **Rationale**: Why this decision was made
+
+### 🚫 Constraint: [category]
+- **Rule**: Description (category: architecture | security | code-style | performance)
+- **Priority**: critical | high | medium | low
+- **Tags**: comma-separated tags
+
+---
+`.trim();
+
+/** Marker heading written with PLAN_TEMPLATE; used to avoid duplicate injection. */
+export const PLAN_TEMPLATE_MARKER = '## 📝 Decision/Constraint Recording';
+
+/**
+ * Append Decision/Constraint template to a Grok Build plan.md (file side-effect).
+ *
+ * Skips when the template marker or real 📌/🚫 patterns are already present.
+ *
+ * @param planPath - Absolute path to ~/.grok/sessions/.../plan.md
+ * @returns true if template was written or appended
+ */
+export function injectGrokPlanTemplate(planPath: string): boolean {
+  const planDir = dirname(planPath);
+  if (!existsSync(planDir)) {
+    mkdirSync(planDir, { recursive: true });
+  }
+
+  if (!existsSync(planPath)) {
+    writeFileSync(planPath, `${PLAN_TEMPLATE}\n`, 'utf-8');
+    debugLog('DEBUG', '[grok-plan-template] Created plan.md with template', { planPath });
+    return true;
+  }
+
+  const content = readFileSync(planPath, 'utf-8');
+  if (content.includes(PLAN_TEMPLATE_MARKER) || hasPatterns(content)) {
+    debugLog('DEBUG', '[grok-plan-template] Skipped injection', {
+      planPath,
+      hasMarker: content.includes(PLAN_TEMPLATE_MARKER),
+      hasPatterns: hasPatterns(content),
+    });
+    return false;
+  }
+
+  appendFileSync(planPath, `\n\n${PLAN_TEMPLATE}\n`, 'utf-8');
+  debugLog('DEBUG', '[grok-plan-template] Appended template to plan.md', { planPath });
+  return true;
+}
+
+/**
+ * Warm session cache and inject Decision/Constraint template for a Grok plan.md.
+ *
+ * @returns true if injectGrokPlanTemplate wrote or appended the template
+ */
+export function ensureGrokPlanTemplate(
+  projectPath: string,
+  sessionId: string | undefined,
+  planPathOverride?: string,
+): boolean {
+  const planPath =
+    planPathOverride ||
+    (sessionId ? computeGrokPlanPath(projectPath, sessionId) : null);
+  if (!planPath) {
+    return false;
+  }
+
+  const existing = loadCurrentPlan(projectPath);
+  const samePath = existing?.plan_path === planPath;
+  const planInfo: CurrentPlanInfo = {
+    plan_id: samePath && existing ? existing.plan_id : randomUUID(),
+    plan_file: 'plan.md',
+    plan_path: planPath,
+    plan_updated_at: new Date().toISOString(),
+    recorded: samePath ? (existing?.recorded ?? false) : false,
+    decision_pending: samePath ? (existing?.decision_pending ?? true) : true,
+    enforcement_shown_at: samePath ? existing?.enforcement_shown_at : undefined,
+  };
+  saveCurrentPlan(projectPath, planInfo);
+  return injectGrokPlanTemplate(planPath);
+}

--- a/src/cli/hooks/on-prompt.ts
+++ b/src/cli/hooks/on-prompt.ts
@@ -17,9 +17,12 @@
  */
 
 import { randomUUID } from 'crypto';
+import { existsSync } from 'fs';
 import {
   readStdinJson,
   isPlanMode,
+  readGrokPlanModeState,
+  computeGrokPlanPath,
   getProjectPath,
   sendHermesContext,
   type HookInput,
@@ -35,6 +38,8 @@ import {
   buildSessionContext,
   shouldInjectOnPrompt,
 } from './session-context.js';
+import { ensureGrokPlanTemplate } from './grok-plan-template.js';
+import { debugLog } from '../../utils/debug-logger.js';
 
 // ============================================================================
 // Plan Mode Enforcement Context
@@ -124,11 +129,47 @@ function getHermesEnforcement(projectPath: string): { message: string; planInfo:
 // Main Entry Point
 // ============================================================================
 
+/**
+ * Grok UserPromptSubmit: stdout is ignored (passive hook).
+ * Side-effect only — seed/maintain plan.md Decision/Constraint template when
+ * plan_mode.json reports Active or Pending (covers /plan without enter_plan_mode).
+ */
+function handleGrokPromptSideEffects(input: HookInput): void {
+  const projectPath = getProjectPath(input);
+  const sessionId = input.session_id;
+  if (!projectPath || !sessionId) {
+    return;
+  }
+
+  // Prefer plan_mode.json Active/Pending. If the file is missing (Grok format
+  // change), fall back when plan.md already exists so mid-session re-inject
+  // still works. Inactive/ExitPending → no inject.
+  const state = readGrokPlanModeState(projectPath, sessionId);
+  let shouldEnsure = state === 'Active' || state === 'Pending';
+  if (!shouldEnsure && state === null) {
+    const planPath = computeGrokPlanPath(projectPath, sessionId);
+    shouldEnsure = !!(planPath && existsSync(planPath));
+  }
+  if (!shouldEnsure) {
+    return;
+  }
+
+  const injected = ensureGrokPlanTemplate(projectPath, sessionId);
+  debugLog('DEBUG', '[on-prompt] Grok plan template ensure', {
+    projectPath,
+    sessionId,
+    state,
+    injected,
+  });
+}
+
 export async function onPromptCommand(): Promise<void> {
   try {
     const input = await readStdinJson();
 
     if (input.client === 'grok') {
+      // No stdout — Grok ignores passive hook output. File side-effect only.
+      handleGrokPromptSideEffects(input);
       return;
     }
 

--- a/src/cli/hooks/plan-pattern-extractor.ts
+++ b/src/cli/hooks/plan-pattern-extractor.ts
@@ -243,6 +243,76 @@ export function hasPatterns(content: string): boolean {
   return /#{2,3}\s*📌\s*Decision:/i.test(content) || /#{2,3}\s*🚫\s*Constraint:/i.test(content);
 }
 
+/** Template / placeholder keys after normalizeKey */
+const PLACEHOLDER_KEYS = new Set(['key/path', 'key-path', 'key-name', 'keyname', 'hierarchical/key']);
+
+/** Template / placeholder values (case-insensitive exact or prefix) */
+const PLACEHOLDER_VALUE_EXACT = new Set(['description', 'description of the decision', 'description of the constraint']);
+
+/**
+ * True when the user intentionally recorded "none" (passes exit gate without real ADR).
+ */
+function isIntentionalNone(text: string): boolean {
+  const t = text.trim().toLowerCase();
+  return (
+    t === 'n/a' ||
+    t === 'na' ||
+    t === 'none' ||
+    t === '-' ||
+    t === 'no decisions' ||
+    t === 'no constraints' ||
+    t === 'not applicable'
+  );
+}
+
+function isPlaceholderValue(text: string): boolean {
+  const t = text.trim().toLowerCase();
+  if (!t) return true;
+  if (PLACEHOLDER_VALUE_EXACT.has(t)) return true;
+  // Template constraint rule: "Description (category: architecture | ...)"
+  if (t.startsWith('description (')) return true;
+  return false;
+}
+
+function isFilledDecision(d: ExtractedDecision): boolean {
+  if (isIntentionalNone(d.value) || isIntentionalNone(d.key)) {
+    return true;
+  }
+  if (PLACEHOLDER_KEYS.has(d.key.toLowerCase()) && isPlaceholderValue(d.value)) {
+    return false;
+  }
+  if (isPlaceholderValue(d.value)) {
+    return false;
+  }
+  return d.value.trim().length > 0 && d.key.trim().length > 0;
+}
+
+function isFilledConstraint(c: ExtractedConstraint): boolean {
+  if (isIntentionalNone(c.rule) || isIntentionalNone(c.category)) {
+    return true;
+  }
+  if (isPlaceholderValue(c.rule)) {
+    return false;
+  }
+  // Unfilled template category collapses to architecture via normalizeCategory;
+  // still reject pure template rule text above. Accept any non-empty real rule.
+  return c.rule.trim().length > 0;
+}
+
+/**
+ * True when the plan has at least one **filled** Decision or Constraint
+ * (not the auto-injected placeholder template).
+ *
+ * Intentional empty markers (Value/Rule = "N/A", "none", etc.) count as filled
+ * so agents can exit plan mode when there is nothing to record.
+ *
+ * Used by Grok PreToolUse exit_plan_mode gate (hooks.grok_require_patterns).
+ */
+export function hasFilledPatterns(content: string): boolean {
+  const { decisions, constraints } = extractPatternsFromPlan(content);
+  return decisions.some(isFilledDecision) || constraints.some(isFilledConstraint);
+}
+
 // ============================================================================
 // Path Resolution
 // ============================================================================

--- a/src/cli/hooks/session-context.ts
+++ b/src/cli/hooks/session-context.ts
@@ -11,19 +11,20 @@ import { existsSync, readFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { GitAdapter } from '../../utils/vcs-adapter.js';
 import { resolveConfigPath, loadConfigFile } from '../../config/loader.js';
-import { loadGlobalConfig } from '../../config/global-config.js';
+import {
+  loadGlobalConfig,
+  loadSessionContextMarker,
+  type SessionContextMarker,
+} from '../../config/global-config.js';
 import {
   DEFAULT_SESSION_CONTEXT_BUDGET,
+  DEFAULT_GROK_REQUIRE_PATTERNS,
 } from '../../config/types.js';
 import {
   SESSION_SNAPSHOT_VERSION,
   type SessionSnapshot,
 } from '../../utils/session-snapshot.js';
 import { estimateTokens } from '../../utils/token-estimation.js';
-import {
-  loadSessionContextMarker,
-  type SessionContextMarker,
-} from '../../config/global-config.js';
 
 const STALENESS_DAYS = 30;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -98,6 +99,31 @@ export async function resolveBudget(projectPath: string): Promise<number> {
 
   const globalConfig = loadGlobalConfig();
   return globalConfig.hooks?.session_context_budget ?? DEFAULT_SESSION_CONTEXT_BUDGET;
+}
+
+/**
+ * Resolve hooks.grok_require_patterns (local → global → default true).
+ * Sync for PreToolUse exit gate (no async in track-plan path).
+ */
+export function resolveGrokRequirePatterns(projectPath?: string): boolean {
+  try {
+    if (projectPath) {
+      const localConfig = join(projectPath, '.sqlew', 'config.toml');
+      if (existsSync(localConfig)) {
+        const config = loadConfigFile(projectPath, '.sqlew/config.toml');
+        if (config.hooks?.grok_require_patterns !== undefined) {
+          return config.hooks.grok_require_patterns;
+        }
+      }
+    }
+    const globalConfig = loadGlobalConfig();
+    if (globalConfig.hooks?.grok_require_patterns !== undefined) {
+      return globalConfig.hooks.grok_require_patterns;
+    }
+  } catch {
+    // fail-open to default
+  }
+  return DEFAULT_GROK_REQUIRE_PATTERNS;
 }
 
 /**

--- a/src/cli/hooks/stdin-parser.ts
+++ b/src/cli/hooks/stdin-parser.ts
@@ -7,9 +7,9 @@
  * @since v4.1.0
  */
 
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { homedir } from 'os';
-import { join } from 'path';
+import { join, resolve as pathResolve } from 'path';
 
 import { loadCurrentPlan } from '../../config/global-config.js';
 import { resolvePlanPath } from './plan-pattern-extractor.js';
@@ -183,7 +183,9 @@ const GROK_TOOL_MAP: Record<string, string> = {
   enter_plan_mode: 'EnterPlanMode',
   exit_plan_mode: 'ExitPlanMode',
   search_replace: 'Edit',
+  write: 'Write',
   run_terminal_cmd: 'Bash',
+  run_terminal_command: 'Bash',
   read_file: 'Read',
 };
 
@@ -428,18 +430,122 @@ export function normalizeHookInput(raw: unknown): HookInput {
  * @param sessionId - Grok session id (UUID-like; sanitized to prevent path traversal)
  * @returns Absolute path to the session's plan.md, or null if sessionId is invalid
  */
-export function computeGrokPlanPath(workspaceRoot: string, sessionId: string): string | null {
-  // Sanitize sessionId: it is interpolated into a filesystem path, so restrict it to
-  // the characters a real Grok session id uses (UUID: hex + hyphen). This blocks any
-  // path-traversal payload (`..`, separators) from escaping ~/.grok/sessions/.
+/**
+ * Grok plan-mode state machine values (from session plan_mode.json).
+ * @see ~/.grok/docs/user-guide/19-plan-mode.md
+ */
+export type GrokPlanModeState = 'Active' | 'Pending' | 'ExitPending' | 'Inactive';
+
+/**
+ * Sanitize Grok session id for path use (blocks traversal).
+ */
+function sanitizeGrokSessionId(sessionId: string | undefined): string | null {
   if (!sessionId || !/^[A-Za-z0-9_-]+$/.test(sessionId)) {
     return null;
   }
-  // encodeURIComponent encodes every path separator in workspaceRoot, so it collapses
-  // to a single safe path segment (no traversal possible from the workspace part), and
-  // sessionId is allowlisted above — both inputs are validated before this join.
+  return sessionId;
+}
+
+/**
+ * Build the absolute path to a Grok Build session directory.
+ *
+ *   ~/.grok/sessions/<encodeURIComponent(workspaceRoot)>/<sessionId>
+ */
+export function computeGrokSessionDir(workspaceRoot: string, sessionId: string): string | null {
+  const sid = sanitizeGrokSessionId(sessionId);
+  if (!sid) {
+    return null;
+  }
   // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
-  return join(homedir(), '.grok', 'sessions', encodeURIComponent(workspaceRoot), sessionId, 'plan.md');
+  return join(homedir(), '.grok', 'sessions', encodeURIComponent(workspaceRoot), sid);
+}
+
+export function computeGrokPlanPath(workspaceRoot: string, sessionId: string): string | null {
+  const sessionDir = computeGrokSessionDir(workspaceRoot, sessionId);
+  if (!sessionDir) {
+    return null;
+  }
+  // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
+  return join(sessionDir, 'plan.md');
+}
+
+/**
+ * Read Grok session plan_mode.json state.
+ * Returns null when the file is missing, unreadable, or has an unknown state.
+ *
+ * Note: plan_mode.json is Grok-internal. Callers should keep enter_plan_mode /
+ * PostToolUse re-inject as fallbacks if this API changes.
+ */
+export function readGrokPlanModeState(
+  workspaceRoot: string,
+  sessionId: string,
+): GrokPlanModeState | null {
+  const sessionDir = computeGrokSessionDir(workspaceRoot, sessionId);
+  if (!sessionDir) {
+    return null;
+  }
+  const planModePath = join(sessionDir, 'plan_mode.json');
+  if (!existsSync(planModePath)) {
+    return null;
+  }
+  try {
+    const raw = JSON.parse(readFileSync(planModePath, 'utf-8')) as { state?: string };
+    const state = raw.state;
+    if (
+      state === 'Active' ||
+      state === 'Pending' ||
+      state === 'ExitPending' ||
+      state === 'Inactive'
+    ) {
+      return state;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether Grok plan mode is Active or Pending (template injection should run).
+ */
+export function isGrokPlanModeActive(workspaceRoot: string, sessionId: string): boolean {
+  const state = readGrokPlanModeState(workspaceRoot, sessionId);
+  return state === 'Active' || state === 'Pending';
+}
+
+/**
+ * True when filePath is a Grok Build per-session plan.md under ~/.grok/sessions/.
+ *
+ * When workspaceRoot + sessionId are provided, also accepts an exact match of
+ * computeGrokPlanPath (handles unusual encodings).
+ */
+export function isGrokPlanFile(
+  filePath: string | undefined,
+  workspaceRoot?: string,
+  sessionId?: string,
+): boolean {
+  if (!filePath) {
+    return false;
+  }
+
+  const normalized = filePath.replace(/\\/g, '/');
+  // Typical layout: .../.grok/sessions/<encoded-cwd>/<sessionId>/plan.md
+  if (/(^|\/)\.grok\/sessions\/[^/]+\/[^/]+\/plan\.md$/i.test(normalized)) {
+    return true;
+  }
+
+  if (workspaceRoot && sessionId) {
+    const expected = computeGrokPlanPath(workspaceRoot, sessionId);
+    if (expected) {
+      try {
+        return pathResolve(filePath) === pathResolve(expected);
+      } catch {
+        return false;
+      }
+    }
+  }
+
+  return false;
 }
 
 // ============================================================================

--- a/src/cli/hooks/track-plan.ts
+++ b/src/cli/hooks/track-plan.ts
@@ -15,10 +15,19 @@
  * @since v4.1.0
  * @modified v4.2.2 - Removed LLM extraction, simplified to plan tracking only
  * @modified v4.2.3 - Added template injection on new plan creation
+ * @modified v5.5.x - Grok multi-trigger re-inject via grok-plan-template module
  */
 
 import { randomUUID } from 'crypto';
-import { readStdinJson, sendContinue, isPlanFile, getProjectPath, computeGrokPlanPath } from './stdin-parser.js';
+import {
+  readStdinJson,
+  sendContinue,
+  sendBlock,
+  isPlanFile,
+  isGrokPlanFile,
+  getProjectPath,
+  computeGrokPlanPath,
+} from './stdin-parser.js';
 import { PLAN_MODE_ENFORCEMENT } from './on-prompt.js';
 import { extractPlanFileName, parseFrontmatter, generatePlanId, getPlanId } from './plan-id-utils.js';
 import {
@@ -28,22 +37,31 @@ import {
   clearCurrentPlan,
   type CurrentPlanInfo,
 } from '../../config/global-config.js';
-import { existsSync, readFileSync, writeFileSync, appendFileSync, mkdirSync } from 'fs';
-import { dirname, resolve } from 'path';
-import { hasPatterns } from './plan-pattern-extractor.js';
+import { existsSync, readFileSync } from 'fs';
+import { resolve } from 'path';
 import { debugLog } from '../../utils/debug-logger.js';
+import {
+  injectGrokPlanTemplate,
+  ensureGrokPlanTemplate,
+  PLAN_TEMPLATE_MARKER,
+} from './grok-plan-template.js';
+import { hasFilledPatterns } from './plan-pattern-extractor.js';
+import { resolveGrokRequirePatterns } from './session-context.js';
 
-// ============================================================================
-// Template Constants
-// ============================================================================
+/** Deny reason when Grok exit_plan_mode is blocked for missing filled patterns */
+export const GROK_EXIT_PLAN_DENY_REASON =
+  '[sqlew] Plan has no filled Decision/Constraint blocks. ' +
+  'Add ### 📌 Decision: / ### 🚫 Constraint: with real values (not template placeholders), ' +
+  'or set Value/Rule to "N/A" if none apply. ' +
+  'Disable: hooks.grok_require_patterns = false in config.toml';
 
-/**
- * Decision/Constraint template to inject on new plan creation
- * Compact format for context window efficiency
- */
+// Re-export for existing importers / tests
+export { injectGrokPlanTemplate, ensureGrokPlanTemplate, PLAN_TEMPLATE_MARKER };
+
+/** Template body used for Claude stdout injection on new plan (Claude only). */
 const PLAN_TEMPLATE = `
 ---
-## 📝 Decision/Constraint Recording (auto-detected on ExitPlanMode)
+${PLAN_TEMPLATE_MARKER} (auto-detected on ExitPlanMode)
 
 ### 📌 Decision: [key/path]
 - **Value**: Description
@@ -58,46 +76,6 @@ const PLAN_TEMPLATE = `
 ---
 `.trim();
 
-/** Marker heading written with PLAN_TEMPLATE; used to avoid duplicate injection. */
-export const PLAN_TEMPLATE_MARKER = '## 📝 Decision/Constraint Recording';
-
-/**
- * Append Decision/Constraint template to a Grok Build plan.md (file side-effect).
- *
- * Grok ignores passive/PreToolUse stdout context injection, so we write directly
- * to plan.md on enter_plan_mode. Skips when the template marker or real patterns
- * are already present.
- *
- * @param planPath - Absolute path to ~/.grok/sessions/.../plan.md
- * @returns true if template was written or appended
- */
-export function injectGrokPlanTemplate(planPath: string): boolean {
-  const planDir = dirname(planPath);
-  if (!existsSync(planDir)) {
-    mkdirSync(planDir, { recursive: true });
-  }
-
-  if (!existsSync(planPath)) {
-    writeFileSync(planPath, `${PLAN_TEMPLATE}\n`, 'utf-8');
-    debugLog('DEBUG', '[track-plan] Created Grok plan.md with template', { planPath });
-    return true;
-  }
-
-  const content = readFileSync(planPath, 'utf-8');
-  if (content.includes(PLAN_TEMPLATE_MARKER) || hasPatterns(content)) {
-    debugLog('DEBUG', '[track-plan] Skipped Grok template injection', {
-      planPath,
-      hasMarker: content.includes(PLAN_TEMPLATE_MARKER),
-      hasPatterns: hasPatterns(content),
-    });
-    return false;
-  }
-
-  appendFileSync(planPath, `\n\n${PLAN_TEMPLATE}\n`, 'utf-8');
-  debugLog('DEBUG', '[track-plan] Appended template to Grok plan.md', { planPath });
-  return true;
-}
-
 // ============================================================================
 // Main Entry Point
 // ============================================================================
@@ -105,10 +83,12 @@ export function injectGrokPlanTemplate(planPath: string): boolean {
 /**
  * Main track-plan command entry point
  *
- * Called as PreToolUse hook when Write tool is invoked.
- * Only processes .claude/plans/*.md files.
+ * Called as PreToolUse hook when Write / EnterPlanMode is invoked, and as
+ * PostToolUse for Grok plan.md re-inject after full-file overwrites.
  *
  * v4.2.2: Simplified to plan tracking only. Pattern extraction happens in on-exit-plan.
+ * v5.2.x: Grok enter_plan_mode file injection.
+ * v5.5.x: Grok plan.md PostToolUse re-inject + multi-trigger support.
  */
 export async function trackPlanCommand(): Promise<void> {
   try {
@@ -125,26 +105,85 @@ export async function trackPlanCommand(): Promise<void> {
         // Grok Build: pre-record the per-session plan.md path now (we have the sessionId).
         // This keeps the cache warm; on-exit-plan also recomputes defensively if this is missed.
         if (input.client === 'grok' && input.session_id) {
-          const planPath = computeGrokPlanPath(projectPath, input.session_id);
-          if (planPath) {
-            const planInfo: CurrentPlanInfo = {
-              plan_id: randomUUID(),
-              plan_file: 'plan.md',
-              plan_path: planPath,
-              plan_updated_at: new Date().toISOString(),
-              recorded: false,
-              decision_pending: true,
-            };
-            saveCurrentPlan(projectPath, planInfo);
-            injectGrokPlanTemplate(planPath);
-          }
+          ensureGrokPlanTemplate(projectPath, input.session_id);
         }
       }
       sendContinue(PLAN_MODE_ENFORCEMENT);
       return;
     }
 
-    // Only process plan files for Write tool
+    // Grok PreToolUse exit_plan_mode: deny when plan.md has no filled 📌/🚫
+    // (hooks.grok_require_patterns, default true). PostToolUse extraction is separate.
+    if (input.tool_name === 'ExitPlanMode' && input.client === 'grok') {
+      const projectPath = getProjectPath(input);
+      const requirePatterns = resolveGrokRequirePatterns(projectPath);
+      if (!requirePatterns) {
+        debugLog('DEBUG', '[track-plan] Grok exit gate skipped (grok_require_patterns=false)');
+        sendContinue();
+        return;
+      }
+
+      let planPath: string | null = null;
+      if (projectPath && input.session_id) {
+        planPath = computeGrokPlanPath(projectPath, input.session_id);
+      }
+      if (!planPath && projectPath) {
+        const cached = loadCurrentPlan(projectPath);
+        planPath = cached?.plan_path ?? null;
+      }
+
+      if (!planPath || !existsSync(planPath)) {
+        debugLog('WARN', '[track-plan] Grok exit gate: plan.md missing', { planPath });
+        sendBlock(GROK_EXIT_PLAN_DENY_REASON);
+        return;
+      }
+
+      const content = readFileSync(planPath, 'utf-8');
+      if (!hasFilledPatterns(content)) {
+        debugLog('DEBUG', '[track-plan] Grok exit gate deny: no filled patterns', { planPath });
+        sendBlock(GROK_EXIT_PLAN_DENY_REASON);
+        return;
+      }
+
+      debugLog('DEBUG', '[track-plan] Grok exit gate allow', { planPath });
+      sendContinue();
+      return;
+    }
+
+    // Grok plan.md: re-inject template after edits (PostToolUse) or if PreToolUse
+    // targets the session plan file. Full-file writes wipe prior injects; PostToolUse
+    // appends the template back when marker/patterns are missing.
+    const projectPathForGrok = getProjectPath(input);
+    const grokFilePath =
+      (input.tool_input?.file_path as string | undefined) ||
+      (input.tool_input?.path as string | undefined);
+    if (
+      grokFilePath &&
+      isGrokPlanFile(grokFilePath, projectPathForGrok, input.session_id) &&
+      (input.tool_name === 'Write' ||
+        input.tool_name === 'Edit' ||
+        input.hook_event_name === 'PostToolUse')
+    ) {
+      if (projectPathForGrok) {
+        const isAbsolute =
+          /^[A-Za-z]:[\\/]/.test(grokFilePath) ||
+          grokFilePath.startsWith('/') ||
+          grokFilePath.startsWith('\\');
+        const absolutePath = isAbsolute
+          ? resolve(grokFilePath)
+          : resolve(projectPathForGrok, grokFilePath);
+        ensureGrokPlanTemplate(projectPathForGrok, input.session_id, absolutePath);
+        debugLog('DEBUG', '[track-plan] Grok plan.md ensure template', {
+          absolutePath,
+          event: input.hook_event_name,
+          tool: input.tool_name,
+        });
+      }
+      sendContinue();
+      return;
+    }
+
+    // Only process Claude/Hermes plan files for Write tool
     if (!isPlanFile(input)) {
       sendContinue();
       return;
@@ -208,7 +247,7 @@ export async function trackPlanCommand(): Promise<void> {
     // Build context message
     let contextMsg = `[sqlew] Tracking plan: ${planFileName} (ID: ${planId.slice(0, 8)}...)`;
 
-    // Inject template on new plan creation
+    // Inject template on new plan creation (Claude stdout; ignored on Grok)
     if (isNewPlan) {
       contextMsg += `\n\n${PLAN_TEMPLATE}`;
     }
@@ -234,7 +273,7 @@ export function getCurrentTrackedPlan(projectPath: string): CurrentPlanInfo | nu
 /**
  * Get plan ID from a file path (convenience wrapper)
  *
- * @param filePath - Path to plan file
+ * @param filePath - Path to a plan file
  * @returns Plan ID or null
  */
 export function getPlanIdFromFile(filePath: string): string | null {

--- a/src/config/global-config.ts
+++ b/src/config/global-config.ts
@@ -62,6 +62,8 @@ export interface GlobalDebugConfig {
  */
 export interface GlobalHooksConfig {
   session_context_budget?: number;
+  /** Grok: deny exit_plan_mode without filled 📌/🚫 (default true) */
+  grok_require_patterns?: boolean;
 }
 
 /**
@@ -287,6 +289,10 @@ const CONFIG_TOML_TEMPLATE = `# ~/.config/sqlew/config.toml - Global sqlew confi
 [hooks]
 # Token budget for session-start context injection (default: 500, 0 = disabled)
 # session_context_budget = 500
+
+# Grok Build: deny exit_plan_mode when plan.md has no filled Decision/Constraint
+# (default: true). Set false to allow approve without 📌/🚫 blocks.
+# grok_require_patterns = true
 `;
 
 /**

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -272,6 +272,11 @@ export function validateConfig(config: SqlewConfig): { valid: boolean; errors: s
       errors.push('hooks.session_context_budget must be an integer between 0 and 10000');
     }
   }
+  if (config.hooks?.grok_require_patterns !== undefined) {
+    if (typeof config.hooks.grok_require_patterns !== 'boolean') {
+      errors.push('hooks.grok_require_patterns must be a boolean');
+    }
+  }
 
   return {
     valid: errors.length === 0,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -297,10 +297,19 @@ export interface HooksConfig {
    * Default: 500. Set to 0 to disable injection and snapshot writes.
    */
   session_context_budget?: number;
+  /**
+   * Grok Build: deny exit_plan_mode when plan.md has no filled 📌/🚫 blocks.
+   * Default: true. Set false to allow approve without Decision/Constraint sections.
+   * @since v5.5.x
+   */
+  grok_require_patterns?: boolean;
 }
 
 /** Default session context injection token budget */
 export const DEFAULT_SESSION_CONTEXT_BUDGET = 500;
+
+/** Default: require filled Decision/Constraint on Grok exit_plan_mode */
+export const DEFAULT_GROK_REQUIRE_PATTERNS = true;
 
 /**
  * Project configuration (v3.7.0+)
@@ -427,5 +436,6 @@ export const DEFAULT_CONFIG: SqlewConfig = {
   },
   hooks: {
     session_context_budget: DEFAULT_SESSION_CONTEXT_BUDGET,
+    grok_require_patterns: DEFAULT_GROK_REQUIRE_PATTERNS,
   },
 };

--- a/src/tests/unit/config/hooks-config.test.ts
+++ b/src/tests/unit/config/hooks-config.test.ts
@@ -88,5 +88,49 @@ describe('hooks-config', () => {
       });
       assert.strictEqual(result.valid, false);
     });
+
+    it('should accept grok_require_patterns true/false', () => {
+      assert.strictEqual(
+        validateConfig({
+          ...DEFAULT_CONFIG,
+          hooks: { grok_require_patterns: false },
+        }).valid,
+        true,
+      );
+      assert.strictEqual(
+        validateConfig({
+          ...DEFAULT_CONFIG,
+          hooks: { grok_require_patterns: true },
+        }).valid,
+        true,
+      );
+    });
+
+    it('should reject non-boolean grok_require_patterns', () => {
+      const result = validateConfig({
+        ...DEFAULT_CONFIG,
+        hooks: { grok_require_patterns: 'yes' as unknown as boolean },
+      });
+      assert.strictEqual(result.valid, false);
+      assert.ok(result.errors.some(e => e.includes('grok_require_patterns')));
+    });
+  });
+
+  describe('loadConfigFile grok_require_patterns', () => {
+    it('should merge grok_require_patterns from file', () => {
+      writeFileSync(
+        TEST_CONFIG_PATH,
+        `[hooks]\ngrok_require_patterns = false\n`,
+        'utf-8',
+      );
+      const config = loadConfigFile(TEST_DIR, 'config.toml');
+      assert.strictEqual(config.hooks?.grok_require_patterns, false);
+    });
+
+    it('should default grok_require_patterns to true', () => {
+      writeFileSync(TEST_CONFIG_PATH, `[database]\npath = ".sqlew/test.db"\n`, 'utf-8');
+      const config = loadConfigFile(TEST_DIR, 'config.toml');
+      assert.strictEqual(config.hooks?.grok_require_patterns, true);
+    });
   });
 });

--- a/src/tests/unit/hooks/grok-plan-template-injection.test.ts
+++ b/src/tests/unit/hooks/grok-plan-template-injection.test.ts
@@ -2,17 +2,27 @@
  * Grok Build plan.md template injection unit tests
  *
  * @since v5.2.0
+ * @modified v5.5.x - multi-trigger ensure + plan_mode helpers
  */
 
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
-import { tmpdir } from 'os';
+import { tmpdir, homedir } from 'os';
 import {
   injectGrokPlanTemplate,
+  ensureGrokPlanTemplate,
   PLAN_TEMPLATE_MARKER,
-} from '../../../cli/hooks/track-plan.js';
+} from '../../../cli/hooks/grok-plan-template.js';
+import {
+  computeGrokSessionDir,
+  computeGrokPlanPath,
+  readGrokPlanModeState,
+  isGrokPlanModeActive,
+  isGrokPlanFile,
+  normalizeHookInput,
+} from '../../../cli/hooks/stdin-parser.js';
 
 describe('injectGrokPlanTemplate', () => {
   let testDir: string;
@@ -65,5 +75,116 @@ describe('injectGrokPlanTemplate', () => {
     );
     const injected = injectGrokPlanTemplate(planPath);
     assert.strictEqual(injected, false);
+  });
+
+  it('should re-append after full-file overwrite without template', () => {
+    injectGrokPlanTemplate(planPath);
+    writeFileSync(planPath, '# Overwritten plan\n\nNo template here.\n', 'utf-8');
+    const reinjected = injectGrokPlanTemplate(planPath);
+    assert.strictEqual(reinjected, true);
+    const content = readFileSync(planPath, 'utf-8');
+    assert.ok(content.includes('# Overwritten plan'));
+    assert.ok(content.includes(PLAN_TEMPLATE_MARKER));
+  });
+});
+
+describe('Grok plan path / plan_mode helpers', () => {
+  const workspace = process.platform === 'win32'
+    ? 'C:\\Users\\test\\proj'
+    : '/Users/test/proj';
+  const sessionId = '019f4fb0-79e8-7b12-8fa9-ee90c38fd340';
+
+  it('computeGrokSessionDir should nest under ~/.grok/sessions', () => {
+    const dir = computeGrokSessionDir(workspace, sessionId);
+    assert.ok(dir);
+    assert.strictEqual(
+      dir,
+      join(homedir(), '.grok', 'sessions', encodeURIComponent(workspace), sessionId),
+    );
+  });
+
+  it('computeGrokPlanPath should end with plan.md under session dir', () => {
+    const planPath = computeGrokPlanPath(workspace, sessionId);
+    const sessionDir = computeGrokSessionDir(workspace, sessionId);
+    assert.strictEqual(planPath, join(sessionDir!, 'plan.md'));
+  });
+
+  it('isGrokPlanFile should match session plan paths', () => {
+    const planPath = computeGrokPlanPath(workspace, sessionId)!;
+    assert.strictEqual(isGrokPlanFile(planPath), true);
+    assert.strictEqual(isGrokPlanFile(planPath, workspace, sessionId), true);
+    assert.strictEqual(isGrokPlanFile('/tmp/other.md'), false);
+    assert.strictEqual(isGrokPlanFile('.claude/plans/foo.md'), false);
+  });
+
+  it('readGrokPlanModeState should parse plan_mode.json', () => {
+    const sessionDir = computeGrokSessionDir(workspace, sessionId)!;
+    // Use a temp workspace path under tmpdir so we do not touch real sessions
+    const tmpWs = join(tmpdir(), `sqlew-ws-${Date.now()}`);
+    const sid = 'test-session-abc';
+    const dir = computeGrokSessionDir(tmpWs, sid)!;
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'plan_mode.json'), JSON.stringify({ state: 'Active' }), 'utf-8');
+
+    assert.strictEqual(readGrokPlanModeState(tmpWs, sid), 'Active');
+    assert.strictEqual(isGrokPlanModeActive(tmpWs, sid), true);
+
+    writeFileSync(join(dir, 'plan_mode.json'), JSON.stringify({ state: 'Pending' }), 'utf-8');
+    assert.strictEqual(isGrokPlanModeActive(tmpWs, sid), true);
+
+    writeFileSync(join(dir, 'plan_mode.json'), JSON.stringify({ state: 'Inactive' }), 'utf-8');
+    assert.strictEqual(isGrokPlanModeActive(tmpWs, sid), false);
+
+    rmSync(dir, { recursive: true, force: true });
+    // silence unused
+    void sessionDir;
+  });
+
+  it('normalizeHookInput should map write tool to Write', () => {
+    const result = normalizeHookInput({
+      hookEventName: 'post_tool_use',
+      toolName: 'write',
+      toolInput: { file_path: '/tmp/plan.md' },
+      workspaceRoot: workspace,
+      sessionId,
+    });
+    assert.strictEqual(result.client, 'grok');
+    assert.strictEqual(result.tool_name, 'Write');
+  });
+});
+
+describe('ensureGrokPlanTemplate', () => {
+  let projectPath: string;
+  let sessionId: string;
+  let planPath: string;
+
+  beforeEach(() => {
+    projectPath = join(tmpdir(), `sqlew-proj-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(projectPath, { recursive: true });
+    sessionId = `sess-${Date.now().toString(36)}`;
+    // ensureGrokPlanTemplate uses computeGrokPlanPath(projectPath, sessionId)
+    // which writes under ~/.grok/sessions — use override path for isolation
+    planPath = join(projectPath, 'plan.md');
+  });
+
+  afterEach(() => {
+    if (existsSync(projectPath)) {
+      rmSync(projectPath, { recursive: true, force: true });
+    }
+  });
+
+  it('should inject via planPathOverride without touching real sessions', () => {
+    const injected = ensureGrokPlanTemplate(projectPath, sessionId, planPath);
+    assert.strictEqual(injected, true);
+    assert.ok(existsSync(planPath));
+    assert.ok(readFileSync(planPath, 'utf-8').includes(PLAN_TEMPLATE_MARKER));
+  });
+
+  it('should not duplicate on second ensure', () => {
+    ensureGrokPlanTemplate(projectPath, sessionId, planPath);
+    const second = ensureGrokPlanTemplate(projectPath, sessionId, planPath);
+    assert.strictEqual(second, false);
+    const content = readFileSync(planPath, 'utf-8');
+    assert.strictEqual((content.match(new RegExp(PLAN_TEMPLATE_MARKER, 'g')) || []).length, 1);
   });
 });

--- a/src/tests/unit/hooks/plan-pattern-extractor.test.ts
+++ b/src/tests/unit/hooks/plan-pattern-extractor.test.ts
@@ -7,7 +7,11 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { extractPatternsFromPlan } from '../../../cli/hooks/plan-pattern-extractor.js';
+import {
+  extractPatternsFromPlan,
+  hasFilledPatterns,
+  hasPatterns,
+} from '../../../cli/hooks/plan-pattern-extractor.js';
 
 describe('plan-pattern-extractor', () => {
   describe('extractPatternsFromPlan - constraint reason', () => {
@@ -121,6 +125,63 @@ describe('plan-pattern-extractor', () => {
 
       assert.strictEqual(result.constraints.length, 1);
       assert.strictEqual(result.constraints[0].reason, 'Keys committed to git cannot be rotated');
+    });
+  });
+
+  describe('hasFilledPatterns', () => {
+    const templateOnly = `
+---
+## 📝 Decision/Constraint Recording (auto-detected on ExitPlanMode)
+
+### 📌 Decision: [key/path]
+- **Value**: Description
+- **Layer**: presentation | business | data | infrastructure | cross-cutting
+- **Rationale**: Why this decision was made
+
+### 🚫 Constraint: [category]
+- **Rule**: Description (category: architecture | security | code-style | performance)
+- **Priority**: critical | high | medium | low
+- **Tags**: comma-separated tags
+
+---
+`;
+
+    it('should return false for empty plan', () => {
+      assert.strictEqual(hasFilledPatterns('# Plan\n\nNo ADR.\n'), false);
+    });
+
+    it('should return false for template placeholders only', () => {
+      assert.strictEqual(hasPatterns(templateOnly), true);
+      assert.strictEqual(hasFilledPatterns(templateOnly), false);
+    });
+
+    it('should return true for a real decision', () => {
+      const content = `
+### 📌 Decision: auth/session
+- **Value**: Redis server-side sessions
+- **Layer**: infrastructure
+`;
+      assert.strictEqual(hasFilledPatterns(content), true);
+    });
+
+    it('should return true for intentional N/A', () => {
+      const content = `
+### 📌 Decision: n/a
+- **Value**: N/A
+- **Layer**: cross-cutting
+`;
+      assert.strictEqual(hasFilledPatterns(content), true);
+    });
+
+    it('should return true when plan body has template plus a real block', () => {
+      const content =
+        templateOnly +
+        `
+### 📌 Decision: data/orm
+- **Value**: Keep Knex
+- **Layer**: data
+`;
+      assert.strictEqual(hasFilledPatterns(content), true);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Fix Grok Build Plan-to-ADR reliability: seed 📌/🚫 template on `plan.md` via multi-trigger file side-effects (not stdout)
- Deny `exit_plan_mode` when plan has only empty template placeholders (`hooks.grok_require_patterns`, default true)
- Bump version to **5.3.3**; pair with [sqlew-plugin 5.3.2](https://github.com/sqlew-io/sqlew-plugin)

## Architecture Decisions

### Decision: grok/plan-template-file-injection (extend multi-trigger; stdout unusable on Grok)

Grok passive hooks ignore stdout, so Decision/Constraint sections must be written to `plan.md` on disk. enter_plan_mode-only inject missed `/plan` and was wiped by full-file overwrites.

- `src/cli/hooks/grok-plan-template.ts`: extracted `injectGrokPlanTemplate` / `ensureGrokPlanTemplate` (create/append template; skip on marker or real patterns)
- `src/cli/hooks/track-plan.ts`: enter_plan_mode inject; PostToolUse re-inject on Grok plan.md edits; PreToolUse exit_plan_mode gate
- `src/cli/hooks/on-prompt.ts`: Grok UserPromptSubmit side-effect when `plan_mode.json` is Active/Pending (covers `/plan` without enter_plan_mode)
- `src/cli/hooks/stdin-parser.ts`: `computeGrokSessionDir`, `readGrokPlanModeState`, `isGrokPlanFile`; map `write` → `Write`

### Decision: grok/plan-injection-no-stdout (do not rely on additionalContext)

Passive hook stdout is ignored on Grok; success must not depend on context injection.

- `src/cli/hooks/on-prompt.ts`: Grok path does file side-effects only (no stdout enforcement text)

### Constraint: Grok plan guidance must not require hook stdout (additionalContext)

- `docs/HOOKS_GUIDE.md`, `docs/HARNESS_COMPATIBILITY.md`: document multi-trigger file injection + exit gate

### Constraint: re-inject skips when marker or real 📌/🚫 already present

- `src/cli/hooks/grok-plan-template.ts`, `src/cli/hooks/plan-pattern-extractor.ts` (`hasFilledPatterns` for exit gate vs `hasPatterns` for re-inject skip)

## Other Changes

- `src/config/types.ts`, `global-config.ts`, `loader.ts`: `[hooks] grok_require_patterns` (default true)
- `src/cli/hooks/session-context.ts`: `resolveGrokRequirePatterns`
- `src/tests/unit/**`: unit coverage for helpers, hasFilledPatterns, config
- `docs/CONFIGURATION.md`: config table entry
- `package.json` / `package-lock.json` / `manifest.json` / `CHANGELOG.md`: **5.3.3**

## Test Plan

- [x] `npm run build` + pre-commit unit/feature/database/integration suite
- [x] Unit tests for inject/re-inject, plan_mode helpers, hasFilledPatterns, grok_require_patterns config
- [x] Manual Grok e2e: `/plan` → plan.md gets template; full rewrite re-appends; filled 📌 allows exit; empty template denies exit
- [x] `hooks.grok_require_patterns = false` allows exit without filled patterns
- [x] Claude Code regression: on-prompt stdout path unchanged

## Notes

Requires **sqlew CLI 5.3.3+** and **sqlew-plugin 5.3.2+** (expanded hook matchers for `write` / `search_replace` / exit gate).
