### PR TITLE
fix(project): share same-name projects across different roots (v5.3.4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ CLAUDE.md
 # Cursor MCP tool descriptors (auto-generated)
 mcps/
 agent-tools/
+terminals/
+.hermes/
 
 # Dependencies
 node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,20 @@ The per-tool token consumption feature never worked: its only writer inserted v3
 
 ---
 
+## [5.3.4] - 2026-07-25
+
+### Fixed
+
+**Same project name + different root no longer errors on per-call resolve**
+
+Git worktrees, alias clones, and isolation worktrees often share `[project].name` (or the same detected basename / git remote name) while living at different absolute paths. Startup-time `ensureProject` already treated name as identity and reused the existing row; per-call resolution (`resolveProjectScope` / `project.resolve { root }` / `_sqlew_project.root`) incorrectly rejected writes with `SQLEW_PROJECT_NAME_COLLISION`.
+
+- **Behavior:** name match always reuses the existing `m_projects` row, even when `root` differs from the recorded `project_root_path` (aligned with startup). `project_root_path` stays the first-registered path.
+- **Separation:** set a unique `[project].name` per tree when ADR spaces must not be shared.
+- **Docs:** [SHARED_DATABASE.md](docs/SHARED_DATABASE.md), [CONFIGURATION.md](docs/CONFIGURATION.md).
+
+---
+
 ## [5.3.1] - 2026-06-29
 
 ### Added

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -35,8 +35,10 @@ name = "my-project"              # Required. Alphanumeric, hyphens, underscores.
 display_name = "My Project"      # Optional. Human-readable name (spaces allowed).
 ```
 
-- `name` is auto-detected on first run and written to config.toml. Once set, it becomes the permanent project identifier.
+- `name` is auto-detected on first run and written to config.toml. Once set, it becomes the permanent project identifier (logical project identity in the shared database).
 - Changing `name` requires MCP server restart.
+- **Worktrees / alias clones:** use the **same** `name` so ADRs stay shared across directories. Path is not the identity.
+- **Separate ADR spaces:** set a **different** `name` in each tree's config. Do not rely on “different folder path” alone to split projects.
 
 ## [database] — Database Settings
 

--- a/docs/SHARED_DATABASE.md
+++ b/docs/SHARED_DATABASE.md
@@ -134,6 +134,17 @@ The recommended desktop flow uses the `project` tool to resolve once and reuse a
 
 `project` tool actions: `current` (active project or unbound status), `resolve` (resolve/register, returns a ref), `list` (all registered projects), `validate` (read-only check).
 
+### Same project name, different directories (worktrees / alias clones)
+
+Logical project identity is **`[project].name`**, not the filesystem path. Git worktrees, alias clones, and isolation worktrees that share the same name resolve to the **same** `project_id` and share ADRs — including when you pass `_sqlew_project.root` or call `project.resolve { root }` with a different absolute path.
+
+| Goal | What to set |
+|------|-------------|
+| Share ADRs across checkouts | Same `[project].name` in each tree (or same auto-detected name from git remote / basename) |
+| Keep ADR spaces separate | Different `[project].name` in each `.sqlew/config.toml` |
+
+`project_root_path` in `m_projects` records the first-registered root and is not rewritten when another path reuses the name.
+
 ### Single-project shortcut (env var)
 
 If a desktop server instance only ever works on one project, set `SQLEW_PROJECT_ROOT` in the MCP server's `env` block. This counts as an explicit signal, so the session binds normally and `_sqlew_project` is not needed:
@@ -170,3 +181,7 @@ Yes, all projects using the default global database share the same `sqlew-shared
 ### My desktop agent writes to the wrong project (or none). What do I do?
 
 Desktop apps launch the MCP server from a fixed cwd, so it can't detect your project. Either set `SQLEW_PROJECT_ROOT` in the server's `env` (single-project), or pass `_sqlew_project` per call / use the `project` tool to resolve a `ref` (multi-project). See [Desktop AI Agents](#desktop-ai-agents-claude-desktop--hermes-desktop) above.
+
+### I use a worktree / second clone and expected a separate project (or shared ADRs)
+
+Identity is the project **name**. Same name → shared ADRs across paths; different name → separate spaces. See [Same project name, different directories](#same-project-name-different-directories-worktrees--alias-clones).

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "sqlew",
   "display_name": "sqlew - Context Manager for AI Agents",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "description": "Token-efficient context management for AI coding agents. Record architectural decisions, constraints, and maintain project knowledge across sessions. Supports SQLite local storage and sqlew.io cloud backend.",
   "author": {
     "name": "sqlew.io",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlew",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlew",
-      "version": "5.3.3",
+      "version": "5.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.21.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sqlew",
   "description": "Automated ADR (Architecture Decision Records) for AI Coding Agents - MCP server with SQL-backed decision repository",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "main": "dist/index.js",
   "type": "module",
   "bin": {

--- a/src/help-data/project.toml
+++ b/src/help-data/project.toml
@@ -133,7 +133,7 @@ description = "Check whether a root/name/ref resolves cleanly, without creating 
   "name": "mcp-sqlew"
 }
 '''
-  explanation = "Returns { ok: true, project } when registered, or { ok: false, error, message } (e.g. SQLEW_PROJECT_NOT_FOUND / SQLEW_PROJECT_NAME_COLLISION)"
+  explanation = "Returns { ok: true, project } when registered, or { ok: false, error, message } (e.g. SQLEW_PROJECT_NOT_FOUND). Same name at a different root shares the existing project (worktree / alias clone)."
 
 # -----------------------------------------------------------------------------
 

--- a/src/tests/database/multi-project/project-scope.test.ts
+++ b/src/tests/database/multi-project/project-scope.test.ts
@@ -1,8 +1,9 @@
 /**
- * Desktop AI agent project resolution tests (v5.4)
+ * Desktop AI agent project resolution tests (v5.4+)
  *
  * Covers:
- * - resolveProjectScope: root (create), name (find / not-found), ref, collision
+ * - resolveProjectScope: root (create), name (find / not-found), ref
+ * - Same name + different root shares one project (worktree / alias clone)
  * - AsyncLocalStorage request-scope isolation (concurrency-safe project switch)
  * - P0 unbound guard: fail-closed writes, help allowed, recovery via _sqlew_project
  * - Per-call project targeting end-to-end through LocalBackend.execute
@@ -87,7 +88,7 @@ describe('resolveProjectScope', () => {
     assert.strictEqual(byRef.id, created.id);
   });
 
-  it('rejects a name collision (same name, different root) on write', async () => {
+  it('shares project when same name has different root on write', async () => {
     const knex = getAdapter().getKnex();
     const now = Math.floor(Date.now() / 1000);
     // Pre-register a project named "myproj" rooted elsewhere.
@@ -100,14 +101,55 @@ describe('resolveProjectScope', () => {
       last_active_ts: now,
       metadata: null,
     });
-    // A different directory whose basename is also "myproj".
+    const existing = await knex('m_projects').where({ name: 'myproj' }).first<{ id: number }>();
+    assert.ok(existing);
+
+    // A different directory whose basename is also "myproj" (worktree / alias clone).
     const repo = path.join(tempDir, 'myproj');
     fs.mkdirSync(repo);
 
-    await assert.rejects(
-      () => resolveProjectScope({ root: repo }, { forWrite: true }),
-      (err: unknown) => parseError(err).error === 'SQLEW_PROJECT_NAME_COLLISION'
-    );
+    const meta = await resolveProjectScope({ root: repo }, { forWrite: true });
+    assert.strictEqual(meta.id, existing.id);
+    assert.strictEqual(meta.name, 'myproj');
+    // First-registered path is kept (not rewritten to the second root).
+    assert.strictEqual(meta.project_root_path, '/somewhere/else/myproj');
+  });
+
+  it('read with mismatched root still resolves existing project', async () => {
+    const knex = getAdapter().getKnex();
+    const now = Math.floor(Date.now() / 1000);
+    await knex('m_projects').insert({
+      name: 'myproj',
+      display_name: 'myproj',
+      detection_source: 'config',
+      project_root_path: '/somewhere/else/myproj',
+      created_ts: now,
+      last_active_ts: now,
+      metadata: null,
+    });
+    const existing = await knex('m_projects').where({ name: 'myproj' }).first<{ id: number }>();
+    const repo = path.join(tempDir, 'myproj');
+    fs.mkdirSync(repo);
+
+    const meta = await resolveProjectScope({ root: repo }, { forWrite: false });
+    assert.strictEqual(meta.id, existing!.id);
+  });
+
+  it('name-only resolve does not require root match', async () => {
+    const knex = getAdapter().getKnex();
+    const now = Math.floor(Date.now() / 1000);
+    await knex('m_projects').insert({
+      name: 'named-only',
+      display_name: 'named-only',
+      detection_source: 'config',
+      project_root_path: '/original/named-only',
+      created_ts: now,
+      last_active_ts: now,
+      metadata: null,
+    });
+    const found = await resolveProjectScope({ name: 'named-only' }, { forWrite: false });
+    assert.strictEqual(found.name, 'named-only');
+    assert.strictEqual(found.project_root_path, '/original/named-only');
   });
 });
 
@@ -197,6 +239,27 @@ describe('project tool', () => {
     assert.strictEqual(result.usage._sqlew_project.ref, result.project.ref);
   });
 
+  it('project.resolve by second root returns same ref as first', async () => {
+    const backend = new LocalBackend();
+    // Two directories with the same basename → same detected project name.
+    const rootA = path.join(tempDir, 'clone-a', 'shared-app');
+    const rootB = path.join(tempDir, 'clone-b', 'shared-app');
+    fs.mkdirSync(rootA, { recursive: true });
+    fs.mkdirSync(rootB, { recursive: true });
+
+    const first = (await backend.execute('project', 'resolve', { root: rootA })) as {
+      project: { id: number; ref: string; name: string };
+    };
+    const second = (await backend.execute('project', 'resolve', { root: rootB })) as {
+      project: { id: number; ref: string; name: string };
+    };
+
+    assert.strictEqual(first.project.name, 'shared-app');
+    assert.strictEqual(second.project.name, 'shared-app');
+    assert.strictEqual(second.project.id, first.project.id);
+    assert.strictEqual(second.project.ref, first.project.ref);
+  });
+
   it('list returns registered projects', async () => {
     const backend = new LocalBackend();
     const repo = fs.mkdtempSync(path.join(tempDir, 'repo-'));
@@ -246,5 +309,69 @@ describe('Per-call project targeting (bound singleton)', () => {
     })) as { count: number; decisions: Array<{ value: string }> };
     assert.strictEqual(targeted.count, 1);
     assert.strictEqual(targeted.decisions[0].value, 'PostgreSQL');
+  });
+
+  it('write via _sqlew_project.root on second path hits same project', async () => {
+    const backend = new LocalBackend();
+    const rootA = path.join(tempDir, 'wt-a', 'shared-app');
+    const rootB = path.join(tempDir, 'wt-b', 'shared-app');
+    fs.mkdirSync(rootA, { recursive: true });
+    fs.mkdirSync(rootB, { recursive: true });
+
+    await backend.execute('decision', 'set', {
+      key: 'auth/session',
+      value: 'cookie',
+      _sqlew_project: { root: rootA },
+    });
+
+    // Second checkout (same basename → same name) should see the decision.
+    const fromB = (await backend.execute('decision', 'list', {
+      _sqlew_project: { root: rootB },
+    })) as { count: number; decisions: Array<{ value: string }> };
+    assert.strictEqual(fromB.count, 1);
+    assert.strictEqual(fromB.decisions[0].value, 'cookie');
+
+    // Write from B is still the same project space.
+    await backend.execute('decision', 'set', {
+      key: 'auth/session',
+      value: 'cookie-v2',
+      _sqlew_project: { root: rootB },
+    });
+    const fromA = (await backend.execute('decision', 'list', {
+      _sqlew_project: { root: rootA },
+    })) as { count: number; decisions: Array<{ key: string; value: string }> };
+    assert.strictEqual(fromA.count, 1);
+    assert.strictEqual(fromA.decisions[0].value, 'cookie-v2');
+  });
+
+  it('different project names stay isolated across roots', async () => {
+    const backend = new LocalBackend();
+    const rootAlpha = path.join(tempDir, 'alpha-root');
+    const rootBeta = path.join(tempDir, 'beta-root');
+    fs.mkdirSync(rootAlpha, { recursive: true });
+    fs.mkdirSync(rootBeta, { recursive: true });
+
+    await backend.execute('decision', 'set', {
+      key: 'feature/flag',
+      value: 'alpha-only',
+      _sqlew_project: { root: rootAlpha },
+    });
+    await backend.execute('decision', 'set', {
+      key: 'feature/flag',
+      value: 'beta-only',
+      _sqlew_project: { root: rootBeta },
+    });
+
+    const alpha = (await backend.execute('decision', 'list', {
+      _sqlew_project: { root: rootAlpha },
+    })) as { count: number; decisions: Array<{ value: string }> };
+    const beta = (await backend.execute('decision', 'list', {
+      _sqlew_project: { root: rootBeta },
+    })) as { count: number; decisions: Array<{ value: string }> };
+
+    assert.strictEqual(alpha.count, 1);
+    assert.strictEqual(alpha.decisions[0].value, 'alpha-only');
+    assert.strictEqual(beta.count, 1);
+    assert.strictEqual(beta.decisions[0].value, 'beta-only');
   });
 });

--- a/src/utils/project-scope-resolver.ts
+++ b/src/utils/project-scope-resolver.ts
@@ -13,10 +13,11 @@
  *
  * Resolution order: ref > root > name.
  *
- * Backward compatibility: the m_projects schema is unchanged. Name remains the
- * unique key, so a name that already exists with a *different* root is treated
- * as a collision and rejected on writes (fail-closed) to avoid writing ADRs to
- * the wrong project.
+ * Identity: m_projects.name is the unique logical project key (same as
+ * ProjectContext.ensureProject). Path is not identity — when the same name is
+ * resolved from a different root (git worktree, alias clone, isolation
+ * worktree), the existing row is reused so ADRs stay shared. To keep projects
+ * separate, set a unique [project].name in each tree's .sqlew/config.toml.
  */
 
 import * as path from 'path';
@@ -39,7 +40,7 @@ export interface SqlewProjectInput {
 }
 
 export interface ResolveOptions {
-  /** Whether the calling action mutates data (create-on-missing, collision check). */
+  /** Whether the calling action mutates data (create-on-missing when unknown). */
   forWrite: boolean;
 }
 
@@ -82,11 +83,6 @@ function rowToMetadata(row: ProjectRow): ProjectMetadata {
     project_root_path: row.project_root_path || undefined,
     metadata: row.metadata ? JSON.parse(row.metadata) : undefined,
   };
-}
-
-/** Normalize a filesystem path for comparison (forward slashes, lowercase). */
-function normalizePath(p: string): string {
-  return path.resolve(p).replace(/\\/g, '/').toLowerCase();
 }
 
 /**
@@ -157,8 +153,10 @@ export async function resolveProjectScope(
 /**
  * Find an existing project by name, or create it when permitted.
  *
- * Collision rule: if the name exists with a different recorded root, reject on
- * write (avoid mis-targeting); allow on read (best-effort cross-project query).
+ * Share rule: name is identity. If the name already exists, return that row
+ * even when the caller's root differs from project_root_path (worktrees /
+ * parallel checkouts). Matches ProjectContext.ensureProject. project_root_path
+ * stays the first-registered path (not updated here).
  */
 async function findOrCreate(
   knex: Knex,
@@ -170,21 +168,6 @@ async function findOrCreate(
   const existing = await knex('m_projects').where({ name }).first<ProjectRow>();
 
   if (existing) {
-    if (
-      root &&
-      existing.project_root_path &&
-      normalizePath(existing.project_root_path) !== normalizePath(root)
-    ) {
-      if (opts.forWrite) {
-        fail(
-          'SQLEW_PROJECT_NAME_COLLISION',
-          `Project "${name}" already exists with a different root ` +
-          `("${existing.project_root_path}" vs "${root}"). Set a unique [project].name ` +
-          `in .sqlew/config.toml for this repo to avoid mixing ADRs.`
-        );
-      }
-      // read: fall through and use the existing row (best-effort)
-    }
     return rowToMetadata(existing);
   }
 


### PR DESCRIPTION
## Summary

- Fix `SQLEW_PROJECT_NAME_COLLISION` when the same project name is resolved from different directories (git worktrees, alias clones, isolation worktrees)
- Align per-call `resolveProjectScope` with startup `ensureProject`: name is identity, path is not
- Bump version to 5.3.4; ignore `.hermes/` and `terminals/`

## Architecture Decisions

### Decision: project/multi-root-same-name (same name + different root shares one logical project)

- `src/utils/project-scope-resolver.ts`: remove write-time name/root collision reject; reuse existing `m_projects` row when name matches (same as `ensureProject`)
- `src/tests/database/multi-project/project-scope.test.ts`: replace collision rejection with multi-root share coverage (resolve, `_sqlew_project.root` write, name isolation)
- `docs/SHARED_DATABASE.md`, `docs/CONFIGURATION.md`, `src/help-data/project.toml`, `CHANGELOG.md`: document share vs separate-via-unique-name

### Decision: project/identity-remains-name (logical identity stays m_projects.name UNIQUE)

- No schema migration; `project_root_path` stays first-registered path and is not rewritten
- Separation of ADR spaces requires a different `[project].name`, not a different folder path alone

### Constraint: worktree / alias clones use matching [project].name to share; different name to isolate

- Documented operational rule for parallel checkouts on the shared database

## Other Changes

- `package.json` / `package-lock.json` / `manifest.json`: bump 5.3.3 → 5.3.4
- `.gitignore`: add `terminals/` and `.hermes/`

## Test Plan

- [x] `project-scope.test.ts` — 21 tests pass (share same name/different root, second-root resolve same ref, backend write shares, different names stay isolated)
- [x] pre-commit full suite + build
- [x] pre-push smoke build