### PR TITLE
fix(decision): align help, layers, and analytics validation (v5.3.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,19 @@ The per-tool token consumption feature never worked: its only writer inserted v3
 
 ---
 
+## [5.3.5] - 2026-07-25
+
+### Fixed
+
+**Decision help and layer validation alignment**
+
+- **Help (`decision.toml`)** — document `scopes` (string array) instead of legacy `scope`; document required `analytics` params (`key_pattern`, `aggregation`) and optional filters
+- **Layers** — validators and decision set paths use `STANDARD_LAYERS` so `planning` / `coordination` / `review` (and `documentation`) match the rest of the stack
+- **Action specs** — register `decision.analytics` required/optional params; expand list-action layer hint
+- **Tests** — help accuracy, review layer acceptance, batch error messages list full standard layers
+
+---
+
 ## [5.3.4] - 2026-07-25
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "sqlew",
   "display_name": "sqlew - Context Manager for AI Agents",
-  "version": "5.3.4",
+  "version": "5.3.5",
   "description": "Token-efficient context management for AI coding agents. Record architectural decisions, constraints, and maintain project knowledge across sessions. Supports SQLite local storage and sqlew.io cloud backend.",
   "author": {
     "name": "sqlew.io",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlew",
-  "version": "5.3.4",
+  "version": "5.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlew",
-      "version": "5.3.4",
+      "version": "5.3.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.21.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sqlew",
   "description": "Automated ADR (Architecture Decision Records) for AI Coding Agents - MCP server with SQL-backed decision repository",
-  "version": "5.3.4",
+  "version": "5.3.5",
   "main": "dist/index.js",
   "type": "module",
   "bin": {

--- a/src/help-data/decision.toml
+++ b/src/help-data/decision.toml
@@ -46,10 +46,10 @@ note = "This action does NOT support rationale, alternatives, or tradeoffs param
   description = "Architecture layer: presentation, business, data, infrastructure, cross-cutting, documentation, planning, coordination, review"
 
   [[actions.params]]
-  name = "scope"
-  type = "string"
+  name = "scopes"
+  type = "string[]"
   required = false
-  description = "Module or component scope"
+  description = "Module or component scopes"
 
   [[actions.params]]
   name = "version"
@@ -87,7 +87,7 @@ note = "This action does NOT support rationale, alternatives, or tradeoffs param
   "value": 20,
   "tags": ["database", "performance"],
   "layer": "data",
-  "scope": "api-service"
+  "scopes": ["api-service"]
 }
 '''
   explanation = "Store a numeric decision scoped to a specific service"
@@ -645,7 +645,7 @@ description = "List decision contexts with filtering"
 
 [[actions]]
 name = "analytics"
-description = "Get decision analytics and statistics"
+description = "Get analytics and statistics for numeric decisions"
 
   [[actions.params]]
   name = "action"
@@ -653,14 +653,46 @@ description = "Get decision analytics and statistics"
   required = true
   description = "Must be \"analytics\""
 
+  [[actions.params]]
+  name = "key_pattern"
+  type = "string"
+  required = true
+  description = "SQL LIKE pattern for numeric decision keys (e.g., \"metric/%\")"
+
+  [[actions.params]]
+  name = "aggregation"
+  type = "string"
+  required = true
+  description = "Aggregation type for numeric decisions: avg, sum, max, min, count"
+
+  [[actions.params]]
+  name = "layer"
+  type = "string"
+  required = false
+  description = "Optional layer filter"
+
+  [[actions.params]]
+  name = "time_series"
+  type = "object"
+  required = false
+  description = "Optional time series options: { bucket, start_ts, end_ts }"
+
+  [[actions.params]]
+  name = "percentiles"
+  type = "number[]"
+  required = false
+  description = "Optional percentiles to calculate (e.g., [50, 90, 95, 99])"
+
   [[actions.examples]]
   title = "Get analytics"
   code = '''
 {
-  "action": "analytics"
+  "action": "analytics",
+  "key_pattern": "metric/api-latency/%",
+  "aggregation": "avg"
 }
 '''
-  explanation = "View statistics about decisions (count by layer, status, tags, etc.)"
+  explanation = "Aggregate numeric decisions matching the key pattern"
 
 # -----------------------------------------------------------------------------
 

--- a/src/tests/feature/decision/batch-validation.test.ts
+++ b/src/tests/feature/decision/batch-validation.test.ts
@@ -250,6 +250,23 @@ describe('Batch Validation Integration - Decision Batch Set', () => {
     assert.strictEqual(result.failed, 0);
   });
 
+  it('should accept valid batch with review layer', async () => {
+    const decisions = [
+      {
+        key: 'review-decision',
+        value: 'review notes',
+        layer: 'review',
+        tags: ['review'],
+      },
+    ];
+
+    const result = await setDecisionBatch({ decisions }, adapter);
+
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.inserted, 1);
+    assert.strictEqual(result.failed, 0);
+  });
+
   it('should provide actionable fix instructions in error message', async () => {
     const decisions = [
       { key: 'test', value: 'test', status: 'draf' as any }, // Typo in status
@@ -282,6 +299,9 @@ describe('Batch Validation Integration - Decision Batch Set', () => {
         assert.ok(error.message.includes('infrastructure'));
         assert.ok(error.message.includes('cross-cutting'));
         assert.ok(error.message.includes('documentation'));
+        assert.ok(error.message.includes('planning'));
+        assert.ok(error.message.includes('coordination'));
+        assert.ok(error.message.includes('review'));
         return true;
       }
     );

--- a/src/tests/feature/decision/context-modular.test.ts
+++ b/src/tests/feature/decision/context-modular.test.ts
@@ -78,6 +78,18 @@ describe('Modular Context Implementation Tests', () => {
       assert.equal(result.key, 'test-key-1');
     });
 
+    it('should accept review layer from the standard layer set', async () => {
+      const result = await setDecision({
+        key: 'test-review-layer',
+        value: 'review-layer-value',
+        agent: 'test-agent',
+        layer: 'review'
+      });
+
+      assert.equal(result.success, true);
+      assert.equal(result.key, 'test-review-layer');
+    });
+
     it('should update existing decision', async () => {
       // First create
       await setDecision({

--- a/src/tests/feature/help/help-system.test.ts
+++ b/src/tests/feature/help/help-system.test.ts
@@ -81,6 +81,30 @@ describe('Help System (TOML-based)', () => {
     }
   });
 
+  describe('Decision help accuracy', () => {
+    it('should document scopes parameter for decision.set instead of legacy scope', () => {
+      const action = loader.getAction('decision', 'set');
+
+      assert.ok(action, 'decision.set should exist');
+      const paramNames = action.params.map((param) => param.name);
+
+      assert.ok(paramNames.includes('scopes'), 'decision.set should document scopes');
+      assert.ok(!paramNames.includes('scope'), 'decision.set should not document legacy scope');
+    });
+
+    it('should document required analytics parameters', () => {
+      const action = loader.getAction('decision', 'analytics');
+
+      assert.ok(action, 'decision.analytics should exist');
+      const paramsByName = new Map(action.params.map((param) => [param.name, param]));
+
+      assert.equal(paramsByName.get('key_pattern')?.required, true);
+      assert.equal(paramsByName.get('aggregation')?.required, true);
+      assert.match(paramsByName.get('aggregation')?.description ?? '', /avg/);
+      assert.match(paramsByName.get('aggregation')?.description ?? '', /count/);
+    });
+  });
+
   describe('Example search', () => {
     it('should find examples by keyword', () => {
       const results = loader.searchExamples('decision');

--- a/src/tests/unit/validation/batch-validation.test.ts
+++ b/src/tests/unit/validation/batch-validation.test.ts
@@ -68,9 +68,8 @@ describe('Batch Validation - Enum Values', () => {
   });
 
   it('should suggest closest match for typo (busines → business)', () => {
-    const validLayers = ['presentation', 'business', 'data', 'infrastructure', 'cross-cutting'] as const;
     const errors: BatchValidationError[] = [];
-    validateEnum('busines', 'layer', validLayers, 0, 'Item 0', errors);
+    validateEnum('busines', 'layer', STANDARD_LAYERS, 0, 'Item 0', errors);
 
     assert.strictEqual(errors.length, 1);
     assert.ok(errors[0].fix.includes('business'));

--- a/src/tools/context/internal/queries.ts
+++ b/src/tools/context/internal/queries.ts
@@ -10,7 +10,7 @@ import {
   getOrCreateScope,
   getLayerId
 } from '../../../database.js';
-import { STRING_TO_STATUS, DEFAULT_VERSION, DEFAULT_STATUS, SUGGEST_THRESHOLDS, SUGGEST_LIMITS, VALID_STATUSES } from '../../../constants.js';
+import { STRING_TO_STATUS, DEFAULT_VERSION, DEFAULT_STATUS, SUGGEST_THRESHOLDS, SUGGEST_LIMITS, VALID_STATUSES, STANDARD_LAYERS } from '../../../constants.js';
 import { parseStringArray } from '../../../utils/param-parser.js';
 import { incrementSemver, isValidSemver } from '../../../utils/semver.js';
 import { validateAgainstPolicies } from '../../../utils/policy-validator.js';
@@ -569,9 +569,8 @@ export async function setDecisionInternal(
   // Validate layer if provided; preserve existing layer if not provided on update
   let layerId: number | null = null;
   if (params.layer) {
-    const validLayers = ['presentation', 'business', 'data', 'infrastructure', 'cross-cutting', 'documentation'];
-    if (!validLayers.includes(params.layer)) {
-      throw new Error(`Invalid layer. Must be one of: ${validLayers.join(', ')}`);
+    if (!STANDARD_LAYERS.includes(params.layer as any)) {
+      throw new Error(`Invalid layer. Must be one of: ${STANDARD_LAYERS.join(', ')}`);
     }
     layerId = await getLayerId(adapter, params.layer, trx);
     if (layerId === null) {

--- a/src/tools/context/internal/validation.ts
+++ b/src/tools/context/internal/validation.ts
@@ -4,7 +4,7 @@
 
 import { validateRequired, validateStatus, validateLayer } from '../../../utils/validators.js';
 import { validateActionParams, validateBatchParams } from '../../../utils/parameter-validator.js';
-import { STRING_TO_STATUS } from '../../../constants.js';
+import { STANDARD_LAYERS, STRING_TO_STATUS } from '../../../constants.js';
 import { parseStringArray } from '../../../utils/param-parser.js';
 import type { DatabaseAdapter } from '../../../adapters/types.js';
 import {
@@ -40,11 +40,8 @@ export function validateStatusParam(status?: string): void {
  * Validate layer parameter
  */
 export function validateLayerParam(layer?: string): void {
-  if (layer) {
-    const validLayers = ['presentation', 'business', 'data', 'infrastructure', 'cross-cutting', 'documentation'];
-    if (!validLayers.includes(layer)) {
-      throw new Error(`Invalid layer. Must be one of: ${validLayers.join(', ')}`);
-    }
+  if (layer && !STANDARD_LAYERS.includes(layer as any)) {
+    throw new Error(`Invalid layer. Must be one of: ${STANDARD_LAYERS.join(', ')}`);
   }
 }
 
@@ -112,14 +109,7 @@ export function parseRelativeTime(relativeTime: string): number | null {
 // ============================================================================
 
 const VALID_DECISION_STATUSES = ['active', 'deprecated', 'draft'] as const;
-const VALID_DECISION_LAYERS = [
-  'presentation',
-  'business',
-  'data',
-  'infrastructure',
-  'cross-cutting',
-  'documentation'
-] as const;
+const VALID_DECISION_LAYERS = STANDARD_LAYERS;
 const VALID_AUTO_INCREMENT_LEVELS = ['major', 'minor', 'patch'] as const;
 
 /**

--- a/src/utils/action-specs/decision-specs.ts
+++ b/src/utils/action-specs/decision-specs.ts
@@ -67,7 +67,7 @@ export const DECISION_ACTION_SPECS: Record<string, ActionSpec> = {
       status: 'active',
       include_tags: true
     },
-    hint: "Valid layers: presentation, business, data, infrastructure, cross-cutting. Values truncated to 30 chars; use full_value=true for complete text."
+    hint: "Valid layers: presentation, business, data, infrastructure, cross-cutting, planning, documentation, coordination, review. Values truncated to 30 chars; use full_value=true for complete text."
   },
 
   versions: {
@@ -207,5 +207,17 @@ export const DECISION_ACTION_SPECS: Record<string, ActionSpec> = {
       limit: 50
     },
     hint: "Query decision contexts with optional filters for traceability. Alias: key→decision_key"
+  },
+
+  analytics: {
+    required: ['key_pattern', 'aggregation'],
+    optional: ['layer', 'time_series', 'percentiles'],
+    example: {
+      action: 'analytics',
+      key_pattern: 'metric/api-latency/%',
+      aggregation: 'avg',
+      layer: 'infrastructure'
+    },
+    hint: "Aggregates numeric decisions only. Valid aggregation values: avg, sum, max, min, count."
   }
 };

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -5,6 +5,7 @@
  */
 
 import type { DatabaseAdapter } from '../adapters/index.js';
+import { STANDARD_LAYERS } from '../constants.js';
 
 /**
  * Validates required string parameter (trim and check non-empty)
@@ -81,9 +82,8 @@ export function validatePriorityRange(priority: unknown): number {
  * @throws Error if layer is invalid
  */
 export async function validateLayer(adapter: DatabaseAdapter, layer: string): Promise<number> {
-  const validLayers = ['presentation', 'business', 'data', 'infrastructure', 'cross-cutting'];
-  if (!validLayers.includes(layer)) {
-    throw new Error(`Invalid layer. Must be one of: ${validLayers.join(', ')}`);
+  if (!STANDARD_LAYERS.includes(layer as any)) {
+    throw new Error(`Invalid layer. Must be one of: ${STANDARD_LAYERS.join(', ')}`);
   }
 
   const knex = adapter.getKnex();


### PR DESCRIPTION
## Summary

- Align decision help docs with the real API: `scopes` (array) instead of legacy `scope`, and document required `analytics` parameters
- Use `STANDARD_LAYERS` consistently in validators so `planning` / `coordination` / `review` (and `documentation`) are accepted like the rest of the stack
- Register `decision.analytics` in action-specs so parameter validation matches runtime behavior

## Architecture Decisions

No prior sqlew Decision records matched this diff (suggest returned none). Changes restore consistency with the existing product rule that the nine `STANDARD_LAYERS` in `constants.ts` are the single source of truth for decision layers.

## Other Changes

- `src/help-data/decision.toml`: `scope` → `scopes`; document `analytics` required/optional params and example
- `src/utils/action-specs/decision-specs.ts`: full layer list in list hint; add `analytics` ActionSpec
- `src/utils/validators.ts`, `src/tools/context/internal/validation.ts`, `src/tools/context/internal/queries.ts`: hard-coded layer lists → `STANDARD_LAYERS`
- Tests: help accuracy for scopes/analytics; accept `review` layer; batch error messages include planning/coordination/review

## Test Plan

- [x] pre-commit: full unit/feature/database/integration suite + build
- [x] pre-push smoke build
- [x] Spot-check `decision.help` / `decision.set` with `layer: review` and `scopes: [...]` after merge