### PR TITLE
feat(omp): hooks library and plan materialize for oh-my-pi (v5.3.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [5.3.6] - 2026-07-31
+
+### Added
+
+**oh-my-pi (omp) hooks library + Plan-to-ADR support**
+
+omp has no Claude-style shell `hooks.json`; it runs in-process TypeScript Extensions. This release exports a library surface and plumbing so [sqlew-plugin `.omp-plugin`](https://github.com/sqlew-io/sqlew-plugin) can inject session context and extract Plan-to-ADR.
+
+- **`sqlew/hooks` export** — `src/hooks-api.ts` re-exports pure helpers (`buildSessionContext`, `processPlanPatterns`, plan markers, queue enqueue, enforcement strings). Import does not boot the MCP server.
+- **omp plan materialize** — `src/cli/hooks/omp-plan.ts` mirrors `local://*-plan.md` under `.sqlew/plans/<slug>-plan.md` with absolute `plan_path` for `processPlanPatterns`.
+- **Client plumbing** — `HookInput.client` includes `'omp'`; `isOmpPlanPath` / `OMP_TOOL_MAP`; `OMP_PROJECT_ROOT` in `determineProjectRoot` / `getProjectPath`; `save` excludes `.sqlew/plans/`; CLI fallback on `on-prompt` / `on-session-start`.
+- **Config** — `[hooks] omp_require_patterns` (boolean, default `true`) gates empty proposes (same idea as Grok exit gate).
+
+Pair with sqlew-plugin `.omp-plugin` (`sqlew-omp` Extension).
+
+### Documentation
+
+- **HARNESS_COMPATIBILITY / HOOKS_GUIDE / CONFIGURATION** — omp column, install, event map, `omp_require_patterns`
+
+### Tests
+
+- Unit: `omp-plan`, `omp-project-root`, session-context omp marker dedup
+- Integration: `omp-plan-to-adr` (materialize → queue → already_recorded)
+
+---
+
 ## [Unreleased]
 
 ### Added

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -89,12 +89,14 @@ Authentication, encryption, and scaling are managed by the sqlew cloud service �
 [hooks]
 session_context_budget = 500   # Token budget for session-start context injection (default: 500)
 grok_require_patterns = true   # Grok: deny exit_plan_mode without filled 📌/🚫 (default: true)
+omp_require_patterns = true    # omp: deny xd://propose without filled 📌/🚫 (default: true)
 ```
 
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `session_context_budget` | `500` | Estimated token budget for injected session context. Set to `0` to disable both injection and snapshot writes. Valid range: `0`–`10000` (integer). |
 | `grok_require_patterns` | `true` | Grok Build only. When `true`, PreToolUse on `exit_plan_mode` **denies** approval if `plan.md` has no filled `### 📌 Decision:` / `### 🚫 Constraint:` blocks (template placeholders alone do not count). Set `Value`/`Rule` to `N/A` if nothing to record, or set this to `false` to disable the gate. |
+| `omp_require_patterns` | `true` | oh-my-pi (omp) only. When `true`, Extension blocks write to `xd://propose` / `/xdev/propose` if the materialized plan has no filled 📌/🚫 blocks. |
 
 **Priority:** Config loading uses first-match-wins (local `.sqlew/config.toml` > worktree parent > global `~/.config/sqlew/config.toml` > defaults). There is no deep merge — if a local config file exists, global `[hooks]` settings are not applied.
 

--- a/docs/HARNESS_COMPATIBILITY.md
+++ b/docs/HARNESS_COMPATIBILITY.md
@@ -2,7 +2,7 @@
 
 Which sqlew features work on which AI harness (client). Install [sqlew-plugin](https://github.com/sqlew-io/sqlew-plugin) for hooks and skills unless you use an **Other harness** setup (MCP server only, no plugin).
 
-**Harnesses:** Claude Code · Codex · Grok Build · Hermes · **Other harness** (MCP tools only — Cursor, Claude Desktop, custom clients, …)
+**Harnesses:** Claude Code · Codex · Grok Build · Hermes · oh-my-pi (omp) · **Other harness** (MCP tools only — Cursor, Claude Desktop, custom clients, …)
 
 ## Legend
 
@@ -14,27 +14,27 @@ Which sqlew features work on which AI harness (client). Install [sqlew-plugin](h
 | ✎ | Manual — call MCP tools yourself (`decision`, `suggest`, …); no automation |
 | — | Not available |
 
-Minimum sqlew versions: Grok Build **5.2+**, Codex **5.2.1+**, Hermes **5.3.0+**, session context injection **5.4.0+** (unreleased until tagged).
+Minimum sqlew versions: Grok Build **5.2+**, Codex **5.2.1+**, Hermes **5.3.0+**, oh-my-pi (omp) Extension **5.4.0+**, session context injection **5.4.0+** (unreleased until tagged).
 
 ---
 
 ## Feature matrix
 
-| Feature | Claude Code | Codex | Grok Build | Hermes | Other harness |
-|---------|:-----------:|:-----:|:----------:|:------:|:--------------:|
-| **MCP tools** (`decision`, `constraint`, `suggest`, `project`, `queue`, …) | ✓ | ✓ | ✓ | ✓ | ✓ |
-| **Session context injection** (recent decisions + active constraints at session start) | ✓ | △ | — | ✓ | ✎ |
-| **Plan mode enforcement** (suggest-before-plan, 📌/🚫 format) | ✓ | △ | ◎+file | ✓ | ✎ |
-| **Plan-to-ADR extraction** (📌 Decision / 🚫 Constraint → DB) | ✓ | △ | △ | △ | ✎ |
-| **Plan file tracking** (`track-plan`) | ✓ | ✓ | ✓ | ✓ | — |
-| **Decision draft on code edit** (`save` hook) | ✓ | ✓ | ✓ | ✓ | — |
-| **Related-context suggest** (`suggest` on Task / delegate) | ✓ | ✓ | △ | △ | ✎ |
-| **PR ADR guard** (`pr-adr` on `gh pr create`) | ✓ | ✓ | △ | ✓ | — |
-| **Todo completion → decision status** (`check-completion`) | ✓ | ✓ | △ | ✓ | — |
-| **Plan-to-ADR rescue on session clear** (`on-session-start`, source=clear) | ✓ | △ | — | — | — |
-| **PR body ADR enrichment** (`sqlew-pr-adr` skill) | ✓ | ✓ | ◎ | ◎ | — |
-| **Slash command** `/sqlew` | ✓ | △ | △ | — | — |
-| **Desktop project targeting** (`project` tool / `_sqlew_project`) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Feature | Claude Code | Codex | Grok Build | Hermes | omp | Other harness |
+|---------|:-----------:|:-----:|:----------:|:------:|:---:|:--------------:|
+| **MCP tools** (`decision`, `constraint`, `suggest`, `project`, `queue`, …) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **Session context injection** (recent decisions + active constraints at session start) | ✓ | △ | — | ✓ | ✓ | ✎ |
+| **Plan mode enforcement** (suggest-before-plan, 📌/🚫 format) | ✓ | △ | ◎+file | ✓ | ✓ | ✎ |
+| **Plan-to-ADR extraction** (📌 Decision / 🚫 Constraint → DB) | ✓ | △ | △ | △ | ✓ | ✎ |
+| **Plan file tracking** (`track-plan`) | ✓ | ✓ | ✓ | ✓ | ✓ | — |
+| **Decision draft on code edit** (`save` hook) | ✓ | ✓ | ✓ | ✓ | ✓ | — |
+| **Related-context suggest** (`suggest` on Task / delegate) | ✓ | ✓ | △ | △ | △ | ✎ |
+| **PR ADR guard** (`pr-adr` on `gh pr create`) | ✓ | ✓ | △ | ✓ | ✓ | — |
+| **Todo completion → decision status** (`check-completion`) | ✓ | ✓ | △ | ✓ | ✓ | — |
+| **Plan-to-ADR rescue on session clear** (`on-session-start`, source=clear) | ✓ | △ | — | — | △ | — |
+| **PR body ADR enrichment** (`sqlew-pr-adr` skill) | ✓ | ✓ | ◎ | ◎ | ◎ | — |
+| **Slash command** `/sqlew` | ✓ | △ | △ | — | — | — |
+| **Desktop project targeting** (`project` tool / `_sqlew_project`) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 
 ### Other harness — what is this column?
 
@@ -65,6 +65,7 @@ Plugin skills (`sqlew-decision-format`) remind the agent of this format when nee
 | **Codex** | **Plan mode** (enable `[features] collaboration_modes = true` first) | When the agent **stops** after planning | Trust bundled hooks via `/hooks` after install. |
 | **Grok Build** | **Plan mode** | When you **approve the plan** | Skills guide 📌/🚫 format; hooks read `plan.md` on approve (stdout injection is passive). |
 | **Hermes** | **`/plan <prompt>`** (plan skill → `.hermes/plans/*.md`) | When the **plan file is written or updated** | No native Plan mode — extraction runs on plan-file saves; `save` promotes drafts when you edit code. |
+| **oh-my-pi (omp)** | **Plan mode** + `local://*-plan.md` | When you **write xd://propose** (approve) | Extension maps events in-process; plans materialize under `.sqlew/plans/`. |
 | **Other harness** | No auto flow | When **you** call MCP `decision` / `constraint` | Use `decision set` and `constraint add` explicitly. |
 
 ---
@@ -86,6 +87,10 @@ Most hooks work after trusting bundled hooks (`/hooks`). Plan mode needs `collab
 ### Hermes
 
 Context injection only on `pre_llm_call` and `pre_tool_call` block. No `ExitPlanMode` — extraction relies on writes to `.hermes/plans/`. Install via `.hermes-plugin` bundle, not the Claude/Codex manifest.
+
+### oh-my-pi (omp)
+
+In-process **Extension** (not shell `hooks.json`). Install `.omp-plugin` from sqlew-plugin; requires `sqlew` with `sqlew/hooks` export. Session context via `before_agent_start`; Plan-to-ADR on `xd://propose` / `/xdev/propose`; plans materialize to `.sqlew/plans/<slug>-plan.md`. Propose gate: `hooks.omp_require_patterns` (default true). MCP still comes from project `.mcp.json`.
 
 ### Other harness
 

--- a/docs/HOOKS_GUIDE.md
+++ b/docs/HOOKS_GUIDE.md
@@ -127,15 +127,60 @@ hermes plugins remove sqlew
 
 Merged `config.yaml` entries and skills under `~/.hermes/skills/sqlew-*` are not removed automatically.
 
+## oh-my-pi (omp)
+
+Requires sqlew **>= 5.4.0** with the `sqlew/hooks` package export. Uses an in-process **Extension** (`.omp-plugin/`), not Claude-style shell hooks.
+
+**Install:**
+
+```bash
+npm i -g sqlew
+omp --extension /path/to/sqlew-plugin/.omp-plugin
+# or:
+omp plugin install /path/to/sqlew-plugin/.omp-plugin
+```
+
+Sync skills into the bundle before install:
+
+```powershell
+pwsh ./scripts/sync-omp-skills.ps1
+```
+
+**Event map (Extension):**
+
+| omp event | Behavior |
+|-----------|----------|
+| `session_start` | Load snapshot → pending session context + marker (`harness: omp`) |
+| `before_agent_start` | Deliver session context once (first message wins) |
+| `turn_start` (plan mode) | FULL then SHORT plan guidance via `sendMessage` |
+| `tool_call` write `local://*-plan.md` | Ensure 📌/🚫 template; materialize `.sqlew/plans/` |
+| `tool_call` write `xd://propose` | Optional filled-pattern gate; `processPlanPatterns` |
+| `tool_result` implementation write | `sqlew save` CLI |
+| `session_stop` | Fallback extract if `decision_pending && !recorded` |
+
+**Config:**
+
+```toml
+[hooks]
+session_context_budget = 500
+omp_require_patterns = true   # block propose without filled 📌/🚫 (default)
+```
+
+Plans are mirrored to `<project>/.sqlew/plans/<slug>-plan.md` so extraction always has an absolute `plan_path`.
+
+MCP: keep using project `.mcp.json`; the Extension does not re-register MCP when already present.
+
+Source: https://github.com/sqlew-io/sqlew-plugin (`.omp-plugin/`)
+
 ## What Gets Configured
 
-| Feature | Claude Code | Codex | Grok Build | Hermes |
-|---------|-------------|-------|------------|--------|
-| Install | `claude plugin install` | `codex plugin install` | `grok plugin install` | `hermes plugins install …/.hermes-plugin` |
-| MCP server | Plugin `.mcp.json` | Plugin `.mcp.json` | Plugin `.mcp.json` | `config.yaml` merge |
-| Plan-to-ADR | Skills + Hooks | Skills + Hooks | Skills + Hooks | Skills + shell hooks |
-| PR enrichment | Skill + Hook | Skill + Hook | Skill + Hook | Hook (`pr-adr`) |
-| Decision format guidance | Skill (sqlew-decision-format) | Skill (sqlew-decision-format) | Skill (sqlew-decision-format) | Skill |
+| Feature | Claude Code | Codex | Grok Build | Hermes | omp |
+|---------|-------------|-------|------------|--------|-----|
+| Install | `claude plugin install` | `codex plugin install` | `grok plugin install` | `hermes plugins install …/.hermes-plugin` | `omp --extension …/.omp-plugin` |
+| MCP server | Plugin `.mcp.json` | Plugin `.mcp.json` | Plugin `.mcp.json` | `config.yaml` merge | Project `.mcp.json` |
+| Plan-to-ADR | Skills + Hooks | Skills + Hooks | Skills + Hooks | Skills + shell hooks | Extension + `sqlew/hooks` |
+| PR enrichment | Skill + Hook | Skill + Hook | Skill + Hook | Hook (`pr-adr`) | Extension → `pr-adr` CLI |
+| Decision format guidance | Skill (sqlew-decision-format) | Skill (sqlew-decision-format) | Skill (sqlew-decision-format) | Skill | Skill |
 
 ## Session Context Injection (v5.4.0+)
 
@@ -172,7 +217,7 @@ Grok Build hooks are passive — stdout injection is ignored. Session context in
 
 ## Version History
 
-- **v5.4.0**: Session context injection (snapshot file, multi-harness delivery, `[hooks]` config)
+- **v5.4.0**: Session context injection (snapshot file, multi-harness delivery, `[hooks]` config); oh-my-pi (omp) Extension (`sqlew/hooks` export, plan materialize, propose gate)
 - **v5.3.0**: Hermes hook adapter (event/tool normalization, `.hermes/plans`, `pre_llm_call` context injection)
 - **v5.2.1**: Codex plugin support via sqlew-plugin (`.codex-plugin`, marketplace, hook normalization, transcript-based plan extraction)
 - **v5.2.0**: Grok Build support via sqlew-plugin (hook normalization, Grok plan path, skills-based plan guidance)

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "sqlew",
   "display_name": "sqlew - Context Manager for AI Agents",
-  "version": "5.3.5",
+  "version": "5.3.6",
   "description": "Token-efficient context management for AI coding agents. Record architectural decisions, constraints, and maintain project knowledge across sessions. Supports SQLite local storage and sqlew.io cloud backend.",
   "author": {
     "name": "sqlew.io",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlew",
-  "version": "5.3.5",
+  "version": "5.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlew",
-      "version": "5.3.5",
+      "version": "5.3.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.21.1",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,15 @@
 {
   "name": "sqlew",
   "description": "Automated ADR (Architecture Decision Records) for AI Coding Agents - MCP server with SQL-backed decision repository",
-  "version": "5.3.5",
+  "version": "5.3.6",
   "main": "dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./hooks": {
+      "types": "./dist/hooks-api.d.ts",
+      "import": "./dist/hooks-api.js"
+    }
+  },
   "type": "module",
   "bin": {
     "sqlew": "dist/index.js"

--- a/src/cli/hooks/omp-plan.ts
+++ b/src/cli/hooks/omp-plan.ts
@@ -1,0 +1,231 @@
+/**
+ * omp plan materialization helpers.
+ *
+ * omp plans live as session-local `local://<slug>-plan.md` artifacts.
+ * processPlanPatterns needs an absolute plan_path, so we mirror content under
+ * `<project>/.sqlew/plans/<slug>-plan.md` (same idea as Grok/Codex materialize).
+ *
+ * @since v5.4.0
+ */
+
+import { createHash, randomUUID } from 'crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import {
+  loadCurrentPlan,
+  saveCurrentPlan,
+  type CurrentPlanInfo,
+} from '../../config/global-config.js';
+import { hasPatterns } from './plan-pattern-extractor.js';
+import { PLAN_TEMPLATE_MARKER } from './grok-plan-template.js';
+import { isOmpPlanPath } from './stdin-parser.js';
+
+/** Decision/Constraint template body (shared wording with Grok). */
+const OMP_PLAN_TEMPLATE = `
+---
+## 📝 Decision/Constraint Recording (auto-detected on ExitPlanMode)
+
+### 📌 Decision: [key/path]
+- **Value**: Description
+- **Layer**: presentation | business | data | infrastructure | cross-cutting
+- **Rationale**: Why this decision was made
+
+### 🚫 Constraint: [category]
+- **Rule**: Description (category: architecture | security | code-style | performance)
+- **Priority**: critical | high | medium | low
+- **Tags**: comma-separated tags
+
+---
+`.trim();
+
+export function ompPlansDir(projectPath: string): string {
+  return join(projectPath, '.sqlew', 'plans');
+}
+
+function contentHash(content: string): string {
+  return createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+/**
+ * Extract slug from omp plan path forms:
+ * - local://foo-plan.md → foo
+ * - /abs/.sqlew/plans/foo-plan.md → foo
+ * - foo-plan.md → foo
+ * - xd://propose / slug body → null (caller handles propose separately)
+ */
+export function extractSlugFromOmpPlanPath(filePath: string): string | null {
+  if (!filePath) return null;
+  const p = filePath.replace(/\\/g, '/').trim();
+
+  // propose devices are not plan slugs
+  if (
+    p === 'xd://propose' ||
+    p === '/xdev/propose' ||
+    p.endsWith('/xdev/propose')
+  ) {
+    return null;
+  }
+
+  let name = p;
+  const localMatch = /^local:\/\/(.+)$/i.exec(p);
+  if (localMatch) {
+    name = localMatch[1];
+  } else {
+    const slash = p.lastIndexOf('/');
+    if (slash >= 0) name = p.slice(slash + 1);
+  }
+
+  // strip query/hash if any
+  name = name.split('?')[0].split('#')[0];
+
+  if (!name.toLowerCase().endsWith('.md')) {
+    // bare slug without -plan.md
+    if (name.length > 0 && !name.includes('/')) {
+      return name.replace(/-plan$/i, '') || null;
+    }
+    return null;
+  }
+
+  const base = name.slice(0, -3); // drop .md
+  const withoutPlan = base.replace(/-plan$/i, '');
+  return withoutPlan.length > 0 ? withoutPlan : null;
+}
+
+/**
+ * Append Decision/Constraint template when marker and real patterns are absent.
+ */
+export function ensureOmpPlanTemplate(content: string): {
+  content: string;
+  injected: boolean;
+} {
+  if (!content) {
+    return { content: `${OMP_PLAN_TEMPLATE}\n`, injected: true };
+  }
+  if (content.includes(PLAN_TEMPLATE_MARKER) || hasPatterns(content)) {
+    return { content, injected: false };
+  }
+  const sep = content.endsWith('\n') ? '\n' : '\n\n';
+  return { content: `${content}${sep}${OMP_PLAN_TEMPLATE}\n`, injected: true };
+}
+
+/**
+ * Write plan content under .sqlew/plans and update CurrentPlanInfo.
+ */
+export function materializeOmpPlan(opts: {
+  projectPath: string;
+  slug: string;
+  content: string;
+  sessionId?: string;
+}): { planPath: string; planInfo: CurrentPlanInfo } {
+  const { projectPath, slug, content } = opts;
+  const safeSlug = slug.replace(/[^a-zA-Z0-9._-]/g, '-').replace(/^-+|-+$/g, '') || 'plan';
+  const planFile = `${safeSlug}-plan.md`;
+  const dir = ompPlansDir(projectPath);
+  mkdirSync(dir, { recursive: true });
+  const planPath = join(dir, planFile).replace(/\\/g, '/');
+
+  const existing = loadCurrentPlan(projectPath);
+  const samePath =
+    existing?.plan_path?.replace(/\\/g, '/') === planPath ||
+    existing?.plan_file === planFile;
+
+  let previousHash: string | undefined;
+  if (samePath && existsSync(planPath)) {
+    try {
+      previousHash = contentHash(readFileSync(planPath, 'utf-8'));
+    } catch {
+      previousHash = undefined;
+    }
+  }
+
+  writeFileSync(planPath, content, 'utf-8');
+  const newHash = contentHash(content);
+
+  let recorded = false;
+  let planId: string = randomUUID();
+  let decisionPending = true;
+  let enforcementShownAt: string | undefined;
+
+  if (samePath && existing) {
+    planId = existing.plan_id;
+    enforcementShownAt = existing.enforcement_shown_at;
+    if (existing.recorded && previousHash === newHash) {
+      recorded = true;
+      decisionPending = existing.decision_pending ?? false;
+    } else if (existing.recorded && previousHash !== newHash) {
+      // content changed after recorded → allow re-extract
+      recorded = false;
+      decisionPending = true;
+    } else {
+      recorded = existing.recorded;
+      decisionPending = existing.decision_pending ?? true;
+    }
+  }
+
+  const planInfo: CurrentPlanInfo = {
+    plan_id: planId,
+    plan_file: planFile,
+    plan_path: planPath,
+    plan_updated_at: new Date().toISOString(),
+    recorded,
+    decision_pending: decisionPending,
+    enforcement_shown_at: enforcementShownAt,
+  };
+  saveCurrentPlan(projectPath, planInfo);
+  return { planPath, planInfo };
+}
+
+/**
+ * Track omp plan from a path (local:// or absolute materialized).
+ * When content is provided, materializes/updates the file.
+ */
+export function trackOmpPlanFromPath(opts: {
+  projectPath: string;
+  filePath: string;
+  content?: string;
+  sessionId?: string;
+}): CurrentPlanInfo {
+  const { projectPath, filePath, content, sessionId } = opts;
+  const slug = extractSlugFromOmpPlanPath(filePath) ?? 'plan';
+
+  if (content !== undefined) {
+    return materializeOmpPlan({ projectPath, slug, content, sessionId }).planInfo;
+  }
+
+  // No content: if already materialized, just refresh tracking metadata
+  const planFile = `${slug}-plan.md`;
+  const planPath = join(ompPlansDir(projectPath), planFile).replace(/\\/g, '/');
+
+  if (existsSync(planPath)) {
+    const existingContent = readFileSync(planPath, 'utf-8');
+    return materializeOmpPlan({
+      projectPath,
+      slug,
+      content: existingContent,
+      sessionId,
+    }).planInfo;
+  }
+
+  // Absolute path that is already a real file
+  const normalized = filePath.replace(/\\/g, '/');
+  if (!normalized.startsWith('local://') && existsSync(filePath)) {
+    const fileContent = readFileSync(filePath, 'utf-8');
+    return materializeOmpPlan({
+      projectPath,
+      slug,
+      content: fileContent,
+      sessionId,
+    }).planInfo;
+  }
+
+  // Create empty tracked plan with template
+  const { content: templated } = ensureOmpPlanTemplate('');
+  return materializeOmpPlan({
+    projectPath,
+    slug,
+    content: templated,
+    sessionId,
+  }).planInfo;
+}
+
+export { isOmpPlanPath, OMP_PLAN_TEMPLATE, PLAN_TEMPLATE_MARKER };

--- a/src/cli/hooks/on-prompt.ts
+++ b/src/cli/hooks/on-prompt.ts
@@ -176,16 +176,27 @@ export async function onPromptCommand(): Promise<void> {
     const projectPath = getProjectPath(input);
     const sessionId = resolveSessionId(input);
 
-    // Hermes: pre_llm_call — session context + plan guidance in one JSON line
-    if (input.client === 'hermes') {
+    // Hermes / omp CLI fallback: session context + plan guidance as plain/JSON
+    if (input.client === 'hermes' || input.client === 'omp') {
       if (!projectPath) {
-        sendHermesContext(ENFORCEMENT_FULL);
+        if (input.client === 'hermes') {
+          sendHermesContext(ENFORCEMENT_FULL);
+        } else {
+          process.stdout.write(ENFORCEMENT_FULL);
+        }
         return;
       }
 
-      const sessionBlock = await maybeSessionContextBlock(projectPath, sessionId, 'hermes');
+      const harness = input.client;
+      const sessionBlock = await maybeSessionContextBlock(projectPath, sessionId, harness);
       const { message } = getHermesEnforcement(projectPath);
-      sendHermesContext(combineContext(sessionBlock, message));
+      const combined = combineContext(sessionBlock, message);
+      if (input.client === 'hermes') {
+        sendHermesContext(combined);
+      } else {
+        // omp CLI fallback: plain text (extension uses library path, not this)
+        process.stdout.write(combined);
+      }
       return;
     }
 

--- a/src/cli/hooks/on-session-start.ts
+++ b/src/cli/hooks/on-session-start.ts
@@ -69,9 +69,10 @@ export async function onSessionStartCommand(): Promise<void> {
       processClearPlanRescue(projectPath);
     }
 
-    // Session context injection: Claude/Codex on startup or clear only
+    // Session context injection: Claude/Codex/omp on startup or clear only
+    // omp has no source field — missing source defaults to startup above
     const shouldInject =
-      (client === 'claude' || client === 'codex') &&
+      (client === 'claude' || client === 'codex' || client === 'omp') &&
       (source === 'startup' || source === 'clear');
 
     if (shouldInject && projectPath) {

--- a/src/cli/hooks/save.ts
+++ b/src/cli/hooks/save.ts
@@ -39,7 +39,7 @@ function isImplementationFile(filePath: string | undefined): boolean {
   if (normalized.endsWith('.md')) return false;
 
   // Exclude plan files explicitly
-  if (normalized.includes('.claude/plans/') || normalized.includes('.hermes/plans/')) return false;
+  if (normalized.includes('.claude/plans/') || normalized.includes('.hermes/plans/') || normalized.includes('.sqlew/plans/')) return false;
 
   // Exclude documentation directories
   if (normalized.includes('/docs/')) return false;

--- a/src/cli/hooks/session-context.ts
+++ b/src/cli/hooks/session-context.ts
@@ -19,6 +19,7 @@ import {
 import {
   DEFAULT_SESSION_CONTEXT_BUDGET,
   DEFAULT_GROK_REQUIRE_PATTERNS,
+  DEFAULT_OMP_REQUIRE_PATTERNS,
 } from '../../config/types.js';
 import {
   SESSION_SNAPSHOT_VERSION,
@@ -124,6 +125,31 @@ export function resolveGrokRequirePatterns(projectPath?: string): boolean {
     // fail-open to default
   }
   return DEFAULT_GROK_REQUIRE_PATTERNS;
+}
+
+/**
+ * Resolve hooks.omp_require_patterns (local → global → default true).
+ * Sync for omp propose exit gate.
+ */
+export function resolveOmpRequirePatterns(projectPath?: string): boolean {
+  try {
+    if (projectPath) {
+      const localConfig = join(projectPath, '.sqlew', 'config.toml');
+      if (existsSync(localConfig)) {
+        const config = loadConfigFile(projectPath, '.sqlew/config.toml');
+        if (config.hooks?.omp_require_patterns !== undefined) {
+          return config.hooks.omp_require_patterns;
+        }
+      }
+    }
+    const globalConfig = loadGlobalConfig();
+    if (globalConfig.hooks?.omp_require_patterns !== undefined) {
+      return globalConfig.hooks.omp_require_patterns;
+    }
+  } catch {
+    // fail-open to default
+  }
+  return DEFAULT_OMP_REQUIRE_PATTERNS;
 }
 
 /**

--- a/src/cli/hooks/stdin-parser.ts
+++ b/src/cli/hooks/stdin-parser.ts
@@ -94,8 +94,8 @@ export interface HookInput {
   reason?: 'clear' | 'logout' | 'prompt_input_exit' | 'other';
   /** Codex collaboration mode (e.g. plan, default). */
   collaboration_mode?: string;
-  /** Originating client, set by normalizeHookInput() (e.g., 'grok', 'codex', 'hermes'). undefined = Claude/native. */
-  client?: 'grok' | 'codex' | 'claude' | 'hermes';
+  /** Originating client, set by normalizeHookInput() (e.g., 'grok', 'codex', 'hermes', 'omp'). undefined = Claude/native. */
+  client?: 'grok' | 'codex' | 'claude' | 'hermes' | 'omp';
 }
 
 /**
@@ -236,6 +236,29 @@ const HERMES_TOOL_MAP: Record<string, string> = {
 };
 
 const HERMES_NATIVE_TOOLS = new Set(Object.keys(HERMES_TOOL_MAP));
+
+/** omp (oh-my-pi) tool names → Claude canonical tool names. */
+export const OMP_TOOL_MAP: Record<string, string> = {
+  write: 'Write',
+  edit: 'Edit',
+  bash: 'Bash',
+  todo: 'TodoWrite',
+  task: 'Task',
+  read: 'Read',
+};
+
+/**
+ * True when filePath is an omp plan artifact, materialize path, or propose device.
+ */
+export function isOmpPlanPath(filePath: string | undefined): boolean {
+  if (!filePath) return false;
+  const p = filePath.replace(/\\/g, '/');
+  if (/local:\/\/[^/]+-plan\.md$/i.test(p)) return true;
+  if (/(^|\/)[^/]+-plan\.md$/i.test(p) && !p.includes('/node_modules/')) return true;
+  if (/\/\.sqlew\/plans\/[^/]+\.md$/i.test(p)) return true;
+  if (p === 'xd://propose' || p === '/xdev/propose' || p.endsWith('/xdev/propose')) return true;
+  return false;
+}
 const HERMES_NATIVE_EVENTS = new Set(Object.keys(HERMES_EVENT_MAP));
 
 function isHermesPayload(raw: Record<string, unknown>): boolean {
@@ -773,8 +796,11 @@ export function isPlanFile(input: HookInput): boolean {
   const normalizedPath = filePath.replace(/\\/g, '/');
 
   // Match global + project-local plan paths for Claude (.claude/plans/) and
-  // Hermes (.hermes/plans/).
-  return /[/\\]?\.(claude|hermes)\/plans\/[^/]+\.md$/.test(normalizedPath);
+  // Hermes (.hermes/plans/), plus omp plan artifacts / materialize dir.
+  if (/[/\\]?\.(claude|hermes)\/plans\/[^/]+\.md$/.test(normalizedPath)) {
+    return true;
+  }
+  return isOmpPlanPath(filePath);
 }
 
 /**
@@ -805,7 +831,9 @@ export function getProjectPath(input: HookInput): string | undefined {
     process.env.CLAUDE_PROJECT_DIR ||
     process.env.CODEX_CWD ||
     process.env.GROK_WORKSPACE_ROOT ||
-    process.env.TERMINAL_CWD
+    process.env.TERMINAL_CWD ||
+    process.env.OMP_PROJECT_ROOT ||
+    process.env.SQLEW_PROJECT_ROOT
   );
 }
 

--- a/src/config/global-config.ts
+++ b/src/config/global-config.ts
@@ -64,6 +64,8 @@ export interface GlobalHooksConfig {
   session_context_budget?: number;
   /** Grok: deny exit_plan_mode without filled 📌/🚫 (default true) */
   grok_require_patterns?: boolean;
+  /** omp: deny xd://propose without filled 📌/🚫 (default true) */
+  omp_require_patterns?: boolean;
 }
 
 /**

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -277,6 +277,11 @@ export function validateConfig(config: SqlewConfig): { valid: boolean; errors: s
       errors.push('hooks.grok_require_patterns must be a boolean');
     }
   }
+  if (config.hooks?.omp_require_patterns !== undefined) {
+    if (typeof config.hooks.omp_require_patterns !== 'boolean') {
+      errors.push('hooks.omp_require_patterns must be a boolean');
+    }
+  }
 
   return {
     valid: errors.length === 0,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -303,6 +303,12 @@ export interface HooksConfig {
    * @since v5.5.x
    */
   grok_require_patterns?: boolean;
+  /**
+   * oh-my-pi (omp): deny xd://propose when plan has no filled 📌/🚫 blocks.
+   * Default: true.
+   * @since v5.4.0
+   */
+  omp_require_patterns?: boolean;
 }
 
 /** Default session context injection token budget */
@@ -310,6 +316,9 @@ export const DEFAULT_SESSION_CONTEXT_BUDGET = 500;
 
 /** Default: require filled Decision/Constraint on Grok exit_plan_mode */
 export const DEFAULT_GROK_REQUIRE_PATTERNS = true;
+
+/** Default: require filled Decision/Constraint on omp propose */
+export const DEFAULT_OMP_REQUIRE_PATTERNS = true;
 
 /**
  * Project configuration (v3.7.0+)
@@ -437,5 +446,6 @@ export const DEFAULT_CONFIG: SqlewConfig = {
   hooks: {
     session_context_budget: DEFAULT_SESSION_CONTEXT_BUDGET,
     grok_require_patterns: DEFAULT_GROK_REQUIRE_PATTERNS,
+    omp_require_patterns: DEFAULT_OMP_REQUIRE_PATTERNS,
   },
 };

--- a/src/hooks-api.ts
+++ b/src/hooks-api.ts
@@ -1,0 +1,65 @@
+/**
+ * Public library surface for harness adapters (omp Extension, etc.).
+ *
+ * Import as `sqlew/hooks`. Must NOT boot the MCP server or CLI entry.
+ *
+ * @since v5.4.0
+ */
+
+export {
+  buildSessionContext,
+  formatContextBlock,
+  loadSnapshot,
+  resolveBudget,
+  shouldInjectOnPrompt,
+  resolveGrokRequirePatterns,
+  resolveOmpRequirePatterns,
+} from './cli/hooks/session-context.js';
+
+export {
+  processPlanPatterns,
+  type ProcessPlanResult,
+} from './cli/hooks/plan-processor.js';
+
+export {
+  extractPatternsFromPlan,
+  hasPatterns,
+  hasFilledPatterns,
+  buildConfirmationMessage,
+} from './cli/hooks/plan-pattern-extractor.js';
+
+export {
+  loadCurrentPlan,
+  saveCurrentPlan,
+  clearCurrentPlan,
+  loadSessionContextMarker,
+  saveSessionContextMarker,
+  type CurrentPlanInfo,
+  type SessionContextMarker,
+} from './config/global-config.js';
+
+export {
+  enqueueDecisionCreate,
+  enqueueConstraintCreate,
+  enqueueDecisionContextCreate,
+  enqueueDecisionUpdate,
+  enqueueConstraintActivate,
+} from './utils/hook-queue.js';
+
+export {
+  ENFORCEMENT_FULL,
+  ENFORCEMENT_SHORT,
+} from './cli/hooks/on-prompt.js';
+
+export {
+  ompPlansDir,
+  materializeOmpPlan,
+  trackOmpPlanFromPath,
+  extractSlugFromOmpPlanPath,
+  ensureOmpPlanTemplate,
+} from './cli/hooks/omp-plan.js';
+
+export {
+  isOmpPlanPath,
+  OMP_TOOL_MAP,
+} from './cli/hooks/stdin-parser.js';

--- a/src/tests/integration/omp-plan-to-adr.test.ts
+++ b/src/tests/integration/omp-plan-to-adr.test.ts
@@ -1,0 +1,105 @@
+/**
+ * omp Plan-to-ADR integration tests (no omp binary required)
+ *
+ * @since v5.4.0
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, rmSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { materializeOmpPlan, ensureOmpPlanTemplate } from '../../cli/hooks/omp-plan.js';
+import { processPlanPatterns } from '../../cli/hooks/plan-processor.js';
+import { hasFilledPatterns } from '../../cli/hooks/plan-pattern-extractor.js';
+import { saveCurrentPlan, loadCurrentPlan } from '../../config/global-config.js';
+
+const FILLED_PLAN = `# Demo plan
+
+### 📌 Decision: harness/omp-adapter
+- **Value**: in-process Extension + sqlew/hooks
+- **Layer**: infrastructure
+- **Rationale**: omp uses ExtensionAPI not shell hooks
+`;
+
+let testProjectPath: string;
+
+describe('omp plan-to-adr', () => {
+  beforeEach(() => {
+    testProjectPath = join(
+      tmpdir(),
+      `sqlew-omp-adr-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(join(testProjectPath, '.sqlew', 'plans'), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testProjectPath)) {
+      rmSync(testProjectPath, { recursive: true, force: true });
+    }
+  });
+
+  it('processPlanPatterns enqueues decision from materialized plan', () => {
+    const { planPath } = materializeOmpPlan({
+      projectPath: testProjectPath,
+      slug: 'demo',
+      content: FILLED_PLAN,
+    });
+    assert.ok(existsSync(planPath));
+    assert.equal(hasFilledPatterns(FILLED_PLAN), true);
+
+    const result = processPlanPatterns(testProjectPath);
+    assert.equal(result.processed, true, result.skipReason ?? 'expected processed');
+    assert.ok(result.confirmationMessage);
+
+    const plan = loadCurrentPlan(testProjectPath);
+    assert.ok(plan);
+    assert.equal(plan!.recorded, true);
+
+    const queuePath = join(testProjectPath, '.sqlew', 'queue', 'pending.json');
+    assert.ok(existsSync(queuePath), 'pending.json should exist');
+    const queueRaw = readFileSync(queuePath, 'utf-8');
+    assert.ok(
+      queueRaw.includes('harness/omp-adapter') || queueRaw.includes('decision'),
+      `queue should contain decision entry: ${queueRaw.slice(0, 200)}`,
+    );
+  });
+
+  it('second processPlanPatterns returns already_recorded', () => {
+    materializeOmpPlan({
+      projectPath: testProjectPath,
+      slug: 'demo',
+      content: FILLED_PLAN,
+    });
+    const first = processPlanPatterns(testProjectPath);
+    assert.equal(first.processed, true);
+
+    const second = processPlanPatterns(testProjectPath);
+    assert.equal(second.processed, false);
+    assert.ok(
+      second.skipReason === 'already_recorded' ||
+        second.skipReason?.includes('recorded'),
+      `skipReason=${second.skipReason}`,
+    );
+  });
+
+  it('template-only plan fails hasFilledPatterns', () => {
+    const { content } = ensureOmpPlanTemplate('# empty plan\n');
+    assert.equal(hasFilledPatterns(content), false);
+
+    // Propose gate uses hasFilledPatterns; processPlanPatterns still sees
+    // raw 📌/🚫 headings via hasPatterns — gate is what blocks empty proposes.
+    writeFileSync(join(testProjectPath, '.sqlew', 'plans', 'empty-plan.md'), content, 'utf-8');
+    saveCurrentPlan(testProjectPath, {
+      plan_id: 'empty-1',
+      plan_file: 'empty-plan.md',
+      plan_path: join(testProjectPath, '.sqlew', 'plans', 'empty-plan.md').replace(/\\/g, '/'),
+      plan_updated_at: new Date().toISOString(),
+      recorded: false,
+      decision_pending: true,
+    });
+
+    // If extraction yields only placeholders, hasFilledPatterns remains the gate.
+    assert.equal(hasFilledPatterns(readFileSync(join(testProjectPath, '.sqlew', 'plans', 'empty-plan.md'), 'utf-8')), false);
+  });
+});

--- a/src/tests/unit/hooks/omp-plan.test.ts
+++ b/src/tests/unit/hooks/omp-plan.test.ts
@@ -1,0 +1,160 @@
+/**
+ * omp plan materialize helpers unit tests
+ *
+ * @since v5.4.0
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, rmSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  extractSlugFromOmpPlanPath,
+  materializeOmpPlan,
+  ensureOmpPlanTemplate,
+  ompPlansDir,
+} from '../../../cli/hooks/omp-plan.js';
+import { isOmpPlanPath } from '../../../cli/hooks/stdin-parser.js';
+import { loadCurrentPlan, saveCurrentPlan } from '../../../config/global-config.js';
+import { PLAN_TEMPLATE_MARKER } from '../../../cli/hooks/grok-plan-template.js';
+
+let testProjectPath: string;
+
+describe('omp-plan helpers', () => {
+  beforeEach(() => {
+    testProjectPath = join(
+      tmpdir(),
+      `sqlew-omp-plan-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(testProjectPath, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testProjectPath)) {
+      rmSync(testProjectPath, { recursive: true, force: true });
+    }
+  });
+
+  describe('extractSlugFromOmpPlanPath', () => {
+    it('parses local:// slug', () => {
+      assert.equal(extractSlugFromOmpPlanPath('local://demo-plan.md'), 'demo');
+    });
+
+    it('parses .sqlew/plans path', () => {
+      assert.equal(
+        extractSlugFromOmpPlanPath('/abs/project/.sqlew/plans/foo-plan.md'),
+        'foo',
+      );
+    });
+
+    it('parses bare filename', () => {
+      assert.equal(extractSlugFromOmpPlanPath('bar-plan.md'), 'bar');
+    });
+
+    it('returns null for propose devices', () => {
+      assert.equal(extractSlugFromOmpPlanPath('xd://propose'), null);
+      assert.equal(extractSlugFromOmpPlanPath('/xdev/propose'), null);
+    });
+  });
+
+  describe('isOmpPlanPath', () => {
+    it('matches plan artifacts', () => {
+      assert.equal(isOmpPlanPath('local://x-plan.md'), true);
+      assert.equal(isOmpPlanPath('/p/.sqlew/plans/x-plan.md'), true);
+      assert.equal(isOmpPlanPath('xd://propose'), true);
+      assert.equal(isOmpPlanPath('src/a.ts'), false);
+    });
+  });
+
+  describe('ensureOmpPlanTemplate', () => {
+    it('injects when empty', () => {
+      const r = ensureOmpPlanTemplate('');
+      assert.equal(r.injected, true);
+      assert.ok(r.content.includes(PLAN_TEMPLATE_MARKER));
+    });
+
+    it('is idempotent when marker present', () => {
+      const first = ensureOmpPlanTemplate('# Plan\n');
+      const second = ensureOmpPlanTemplate(first.content);
+      assert.equal(second.injected, false);
+      assert.equal(second.content, first.content);
+    });
+
+    it('skips when real patterns present', () => {
+      const content = `### 📌 Decision: a/b
+- **Value**: real
+- **Layer**: business
+`;
+      const r = ensureOmpPlanTemplate(content);
+      assert.equal(r.injected, false);
+    });
+  });
+
+  describe('materializeOmpPlan', () => {
+    it('writes file and CurrentPlanInfo with absolute plan_path', () => {
+      const content = '# demo\n';
+      const { planPath, planInfo } = materializeOmpPlan({
+        projectPath: testProjectPath,
+        slug: 'demo',
+        content,
+      });
+
+      assert.ok(existsSync(planPath));
+      assert.equal(readFileSync(planPath, 'utf-8'), content);
+      assert.ok(planPath.replace(/\\/g, '/').endsWith('.sqlew/plans/demo-plan.md'));
+
+      const loaded = loadCurrentPlan(testProjectPath);
+      assert.ok(loaded);
+      assert.equal(loaded.plan_file, 'demo-plan.md');
+      assert.equal(loaded.plan_path?.replace(/\\/g, '/'), planPath.replace(/\\/g, '/'));
+      assert.equal(loaded.recorded, false);
+      assert.equal(loaded.decision_pending, true);
+      assert.equal(planInfo.plan_id, loaded.plan_id);
+      assert.ok(existsSync(ompPlansDir(testProjectPath)));
+    });
+
+    it('keeps recorded when content hash unchanged', () => {
+      const content = '# same\n';
+      const first = materializeOmpPlan({
+        projectPath: testProjectPath,
+        slug: 'same',
+        content,
+      });
+      saveCurrentPlan(testProjectPath, {
+        ...first.planInfo,
+        recorded: true,
+        decision_pending: false,
+      });
+
+      const second = materializeOmpPlan({
+        projectPath: testProjectPath,
+        slug: 'same',
+        content,
+      });
+      assert.equal(second.planInfo.recorded, true);
+      assert.equal(second.planInfo.plan_id, first.planInfo.plan_id);
+    });
+
+    it('resets recorded when content changes', () => {
+      const first = materializeOmpPlan({
+        projectPath: testProjectPath,
+        slug: 'rev',
+        content: '# v1\n',
+      });
+      saveCurrentPlan(testProjectPath, {
+        ...first.planInfo,
+        recorded: true,
+        decision_pending: false,
+      });
+
+      const second = materializeOmpPlan({
+        projectPath: testProjectPath,
+        slug: 'rev',
+        content: '# v2 changed\n',
+      });
+      assert.equal(second.planInfo.recorded, false);
+      assert.equal(second.planInfo.decision_pending, true);
+    });
+  });
+});

--- a/src/tests/unit/hooks/omp-project-root.test.ts
+++ b/src/tests/unit/hooks/omp-project-root.test.ts
@@ -1,0 +1,67 @@
+/**
+ * OMP_PROJECT_ROOT project-root resolution tests
+ *
+ * @since v5.4.0
+ */
+
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  determineProjectRoot,
+  wasProjectRootExplicit,
+} from '../../../utils/project-root.js';
+
+const ENV_KEYS = [
+  'CLAUDE_PROJECT_DIR',
+  'GROK_WORKSPACE_ROOT',
+  'CODEX_CWD',
+  'TERMINAL_CWD',
+  'OMP_PROJECT_ROOT',
+  'SQLEW_PROJECT_ROOT',
+] as const;
+
+const saved: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {};
+
+function stashEnv(): void {
+  for (const k of ENV_KEYS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+}
+
+function restoreEnv(): void {
+  for (const k of ENV_KEYS) {
+    const v = saved[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+}
+
+describe('OMP_PROJECT_ROOT', () => {
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it('wins over bare cwd when set', () => {
+    stashEnv();
+    process.env.OMP_PROJECT_ROOT = 'C:/Users/kitayama/RustroverProjects/demo';
+    const root = determineProjectRoot();
+    assert.equal(root, 'C:/Users/kitayama/RustroverProjects/demo');
+    assert.equal(wasProjectRootExplicit(), true);
+  });
+
+  it('does not override CLAUDE_PROJECT_DIR', () => {
+    stashEnv();
+    process.env.CLAUDE_PROJECT_DIR = 'C:/claude-project';
+    process.env.OMP_PROJECT_ROOT = 'C:/omp-project';
+    const root = determineProjectRoot();
+    assert.equal(root, 'C:/claude-project');
+  });
+
+  it('is used by getProjectPath fallback', async () => {
+    stashEnv();
+    process.env.OMP_PROJECT_ROOT = 'C:/omp-only';
+    const { getProjectPath } = await import('../../../cli/hooks/stdin-parser.js');
+    assert.equal(getProjectPath({}), 'C:/omp-only');
+  });
+});

--- a/src/tests/unit/hooks/omp-project-root.test.ts
+++ b/src/tests/unit/hooks/omp-project-root.test.ts
@@ -22,6 +22,11 @@ const ENV_KEYS = [
 
 const saved: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {};
 
+// determineProjectRoot uses path.isAbsolute(), which is platform-specific:
+// 'C:/...' is absolute only on win32. Build paths that are absolute on the
+// current platform so the precedence assertions hold on Linux CI too.
+const absRoot = (p: string): string => (process.platform === 'win32' ? `C:${p}` : p);
+
 function stashEnv(): void {
   for (const k of ENV_KEYS) {
     saved[k] = process.env[k];
@@ -44,24 +49,28 @@ describe('OMP_PROJECT_ROOT', () => {
 
   it('wins over bare cwd when set', () => {
     stashEnv();
-    process.env.OMP_PROJECT_ROOT = 'C:/Users/kitayama/RustroverProjects/demo';
+    const ompRoot = absRoot('/Users/kitayama/RustroverProjects/demo');
+    process.env.OMP_PROJECT_ROOT = ompRoot;
     const root = determineProjectRoot();
-    assert.equal(root, 'C:/Users/kitayama/RustroverProjects/demo');
+    assert.equal(root, ompRoot.replace(/\\/g, '/'));
     assert.equal(wasProjectRootExplicit(), true);
   });
 
   it('does not override CLAUDE_PROJECT_DIR', () => {
     stashEnv();
-    process.env.CLAUDE_PROJECT_DIR = 'C:/claude-project';
-    process.env.OMP_PROJECT_ROOT = 'C:/omp-project';
+    const claudeRoot = absRoot('/claude-project');
+    const ompRoot = absRoot('/omp-project');
+    process.env.CLAUDE_PROJECT_DIR = claudeRoot;
+    process.env.OMP_PROJECT_ROOT = ompRoot;
     const root = determineProjectRoot();
-    assert.equal(root, 'C:/claude-project');
+    assert.equal(root, claudeRoot.replace(/\\/g, '/'));
   });
 
   it('is used by getProjectPath fallback', async () => {
     stashEnv();
-    process.env.OMP_PROJECT_ROOT = 'C:/omp-only';
+    const ompRoot = absRoot('/omp-only');
+    process.env.OMP_PROJECT_ROOT = ompRoot;
     const { getProjectPath } = await import('../../../cli/hooks/stdin-parser.js');
-    assert.equal(getProjectPath({}), 'C:/omp-only');
+    assert.equal(getProjectPath({}), ompRoot);
   });
 });

--- a/src/tests/unit/hooks/session-context.test.ts
+++ b/src/tests/unit/hooks/session-context.test.ts
@@ -136,5 +136,15 @@ describe('session-context helpers', () => {
       });
       assert.strictEqual(shouldInjectOnPrompt(testProjectPath, 'same-session'), false);
     });
+
+    it('should dedup omp harness marker for same session_id', () => {
+      saveSessionContextMarker(testProjectPath, {
+        session_id: 'omp-session',
+        injected_at: new Date().toISOString(),
+        harness: 'omp',
+      });
+      assert.strictEqual(shouldInjectOnPrompt(testProjectPath, 'omp-session'), false);
+      assert.strictEqual(shouldInjectOnPrompt(testProjectPath, 'other-omp'), true);
+    });
   });
 });

--- a/src/utils/project-root.ts
+++ b/src/utils/project-root.ts
@@ -6,6 +6,7 @@
  * 0b. GROK_WORKSPACE_ROOT environment variable (Grok Build hooks / MCP)
  * 0c. CODEX_CWD environment variable (Codex hooks / MCP)
  * 0d. TERMINAL_CWD environment variable (Hermes hooks)
+ * 0e. OMP_PROJECT_ROOT environment variable (oh-my-pi extension / MCP)
  * 1. SQLEW_PROJECT_ROOT environment variable (MCP client can set this)
  * 2. CLI --db-path argument (absolute path) → use dirname
  * 3. CLI --config-path argument (absolute path) → use dirname
@@ -110,6 +111,11 @@ export function determineProjectRoot(options: ProjectRootOptions = {}): string {
   if (terminalCwd && path.isAbsolute(terminalCwd)) {
     return terminalCwd.replace(/\\/g, '/');
   }
+  // Priority 0e: OMP_PROJECT_ROOT (oh-my-pi extension / MCP)
+  const ompProjectRoot = process.env.OMP_PROJECT_ROOT;
+  if (ompProjectRoot && path.isAbsolute(ompProjectRoot)) {
+    return ompProjectRoot.replace(/\\/g, '/');
+  }
 
   // Priority 1: SQLEW_PROJECT_ROOT environment variable
   // MCP clients (Junie, Claude Desktop, etc.) can set this to specify project directory
@@ -193,6 +199,7 @@ export function wasProjectRootExplicit(options: ProjectRootOptions = {}): boolea
     process.env.GROK_WORKSPACE_ROOT,
     process.env.CODEX_CWD,
     process.env.TERMINAL_CWD,
+    process.env.OMP_PROJECT_ROOT,
     process.env.SQLEW_PROJECT_ROOT,
   ];
   if (envSignals.some(value => value && path.isAbsolute(value))) {


### PR DESCRIPTION
## Summary

- Export `sqlew/hooks` library surface so oh-my-pi Extensions can call session-context / Plan-to-ADR helpers in-process without booting MCP.
- Materialize omp plans under `.sqlew/plans/<slug>-plan.md` and wire `client: 'omp'`, `OMP_PROJECT_ROOT`, and `hooks.omp_require_patterns`.
- Document omp in harness matrix / hooks guide; pair with sqlew-plugin `.omp-plugin` Extension (already on main).

## Architecture Decisions

### Decision: hooks/session-context-snapshot-architecture (hooks never open DB; MCP writes snapshot)

Session context stays file-based: MCP writes `.sqlew/session-context.json`, hooks/Extension only read it and use the session-cache marker for dedup.

- `src/hooks-api.ts`: re-exports `buildSessionContext` / markers without MCP boot
- `src/cli/hooks/session-context.ts`: `resolveOmpRequirePatterns`; omp uses same snapshot + marker path with `harness: 'omp'`
- `src/cli/hooks/on-session-start.ts` / `on-prompt.ts`: CLI fallback treats `client === 'omp'` like Hermes plain-text path (Extension primary path is library)

### Decision: hooks/session-context-delivery-matrix (per-harness delivery)

omp has no shell hooks.json — delivery is in-process Extension (`before_agent_start` / `turn_start`), backed by this package’s pure helpers.

- `package.json` `exports["./hooks"]`: stable import for sqlew-plugin `.omp-plugin`
- `docs/HARNESS_COMPATIBILITY.md` / `docs/HOOKS_GUIDE.md`: omp column + event map + install

### Decision: harness/omp-adapter-shape (in-process Extension + library, not Claude stdout protocol)

Primary path is library calls from the Extension; Claude-shaped stdout is CLI fallback only.

- `src/cli/hooks/omp-plan.ts`: materialize + template ensure + slug extract
- `src/cli/hooks/stdin-parser.ts`: `client: 'omp'`, `isOmpPlanPath`, `OMP_TOOL_MAP`, project path env fallbacks
- `src/utils/project-root.ts`: `OMP_PROJECT_ROOT` priority
- `src/cli/hooks/save.ts`: exclude `.sqlew/plans/` from implementation promote

### Decision: harness/omp-plan-materialize-path + omp-plan-exit-trigger

Plans live as `'C:\Users\kitayama\.omp\agent\sessions\-RustroverProjects-mcp-sqlew\2026-07-31T00-11-31-896Z_019fb583-0ab8-7000-a330-4bda1c3b1948\local\*-plan.md'`; extraction needs absolute `plan_path`. Exit trigger on harness side is propose (`xd://propose`); core provides materialize + `processPlanPatterns` + filled-pattern gate config.

- `src/cli/hooks/omp-plan.ts`: `.sqlew/plans/<slug>-plan.md` + `CurrentPlanInfo.plan_path`
- `src/config/types.ts` / `loader.ts` / `global-config.ts`: `hooks.omp_require_patterns` (default true)
- `docs/CONFIGURATION.md`: document gate

### Constraint: hooks never open DB; omp_require_patterns default true

- Extension/hooks only read snapshot and enqueue queue files (existing invariant)
- Empty/placeholder plans fail propose gate by default (Grok exit-gate parity)

## Other Changes

- `CHANGELOG.md`, `package.json` / lock / `manifest.json` → **5.3.6**
- Tests: `omp-plan`, `omp-project-root`, `omp-plan-to-adr`, session-context omp marker dedup

## Test Plan

- [x] `npm run build`
- [x] `import('sqlew/hooks')` loads without MCP bind
- [x] Unit + integration omp tests
- [x] Full suite (pre-commit): 629 pass
- [ ] Manual: `omp --extension <sqlew-plugin>/.omp-plugin` — session inject once; propose with filled 📌; template-only propose blocked