### PR TITLE
feat(omp): session-local plan_path without .sqlew/plans copy (v5.3.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [5.3.7] - 2026-07-31
+
+### Changed
+
+**omp Plan-to-ADR: session-local plan_path (no project copy by default)**
+
+- **`resolveOmpPlanFsPath` / `resolveOmpLocalRoot`** — resolve `local://*-plan.md` to the session artifacts file (`<sessionFile-without-.jsonl>/local/...`, Win long-path short root fallback) without depending on `@oh-my-pi/pi-coding-agent`.
+- **`materializeOmpPlan`** — tracks `CurrentPlanInfo.plan_path` only (no write). Project `.sqlew/plans/` mirror remains **legacy fallback** when resolve fails.
+- **`hooks-api`** — exports the new resolve helpers for the omp Extension.
+- **Docs / tests** — HOOKS_GUIDE, HARNESS_COMPATIBILITY, CONFIGURATION; unit + integration cover session-local track and no default mirror.
+
+Pair with sqlew-plugin `.omp-plugin` that passes `sessionFile` + `planPath` into track/materialize.
+
+
 ## [5.3.6] - 2026-07-31
 
 ### Added

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -96,7 +96,7 @@ omp_require_patterns = true    # omp: deny xd://propose without filled 📌/🚫
 |---------|---------|-------------|
 | `session_context_budget` | `500` | Estimated token budget for injected session context. Set to `0` to disable both injection and snapshot writes. Valid range: `0`–`10000` (integer). |
 | `grok_require_patterns` | `true` | Grok Build only. When `true`, PreToolUse on `exit_plan_mode` **denies** approval if `plan.md` has no filled `### 📌 Decision:` / `### 🚫 Constraint:` blocks (template placeholders alone do not count). Set `Value`/`Rule` to `N/A` if nothing to record, or set this to `false` to disable the gate. |
-| `omp_require_patterns` | `true` | oh-my-pi (omp) only. When `true`, Extension blocks write to `xd://propose` / `/xdev/propose` if the materialized plan has no filled 📌/🚫 blocks. |
+| `omp_require_patterns` | `true` | oh-my-pi (omp) only. When `true`, Extension blocks write to `xd://propose` / `/xdev/propose` if the tracked plan has no filled 📌/🚫 blocks. |
 
 **Priority:** Config loading uses first-match-wins (local `.sqlew/config.toml` > worktree parent > global `~/.config/sqlew/config.toml` > defaults). There is no deep merge — if a local config file exists, global `[hooks]` settings are not applied.
 

--- a/docs/HARNESS_COMPATIBILITY.md
+++ b/docs/HARNESS_COMPATIBILITY.md
@@ -65,7 +65,7 @@ Plugin skills (`sqlew-decision-format`) remind the agent of this format when nee
 | **Codex** | **Plan mode** (enable `[features] collaboration_modes = true` first) | When the agent **stops** after planning | Trust bundled hooks via `/hooks` after install. |
 | **Grok Build** | **Plan mode** | When you **approve the plan** | Skills guide 📌/🚫 format; hooks read `plan.md` on approve (stdout injection is passive). |
 | **Hermes** | **`/plan <prompt>`** (plan skill → `.hermes/plans/*.md`) | When the **plan file is written or updated** | No native Plan mode — extraction runs on plan-file saves; `save` promotes drafts when you edit code. |
-| **oh-my-pi (omp)** | **Plan mode** + `local://*-plan.md` | When you **write xd://propose** (approve) | Extension maps events in-process; plans materialize under `.sqlew/plans/`. |
+| **oh-my-pi (omp)** | **Plan mode** + `local://*-plan.md` | When you **write xd://propose** (approve) | Extension maps events in-process; `plan_path` points at the session `local://` file (no project `.sqlew/plans/` copy by default). |
 | **Other harness** | No auto flow | When **you** call MCP `decision` / `constraint` | Use `decision set` and `constraint add` explicitly. |
 
 ---
@@ -90,7 +90,7 @@ Context injection only on `pre_llm_call` and `pre_tool_call` block. No `ExitPlan
 
 ### oh-my-pi (omp)
 
-In-process **Extension** (not shell `hooks.json`). Install `.omp-plugin` from sqlew-plugin; requires `sqlew` with `sqlew/hooks` export. Session context via `before_agent_start`; Plan-to-ADR on `xd://propose` / `/xdev/propose`; plans materialize to `.sqlew/plans/<slug>-plan.md`. Propose gate: `hooks.omp_require_patterns` (default true). MCP still comes from project `.mcp.json`.
+In-process **Extension** (not shell `hooks.json`). Install `.omp-plugin` from sqlew-plugin; requires `sqlew` with `sqlew/hooks` export. Session context via `before_agent_start`; Plan-to-ADR on `xd://propose` / `/xdev/propose`; `local://*-plan.md` is resolved to the session artifacts path and stored as `plan_path` (legacy fallback: `.sqlew/plans/<slug>-plan.md` only if resolve fails). Propose gate: `hooks.omp_require_patterns` (default true). MCP still comes from project `.mcp.json`.
 
 ### Other harness
 

--- a/docs/HOOKS_GUIDE.md
+++ b/docs/HOOKS_GUIDE.md
@@ -153,7 +153,7 @@ pwsh ./scripts/sync-omp-skills.ps1
 | `session_start` | Load snapshot → pending session context + marker (`harness: omp`) |
 | `before_agent_start` | Deliver session context once (first message wins) |
 | `turn_start` (plan mode) | FULL then SHORT plan guidance via `sendMessage` |
-| `tool_call` write `local://*-plan.md` | Ensure 📌/🚫 template; materialize `.sqlew/plans/` |
+| `tool_call` write `local://*-plan.md` | Ensure 📌/🚫 template; track session `local://` path as `plan_path` |
 | `tool_call` write `xd://propose` | Optional filled-pattern gate; `processPlanPatterns` |
 | `tool_result` implementation write | `sqlew save` CLI |
 | `session_stop` | Fallback extract if `decision_pending && !recorded` |
@@ -166,7 +166,7 @@ session_context_budget = 500
 omp_require_patterns = true   # block propose without filled 📌/🚫 (default)
 ```
 
-Plans are mirrored to `<project>/.sqlew/plans/<slug>-plan.md` so extraction always has an absolute `plan_path`.
+`local://` plans resolve to the session artifacts file (`<sessionDir>/local/<slug>-plan.md`) so extraction has an absolute `plan_path` without copying into the project. Legacy fallback writes `.sqlew/plans/` only when resolve fails.
 
 MCP: keep using project `.mcp.json`; the Extension does not re-register MCP when already present.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sqlew",
   "description": "Automated ADR (Architecture Decision Records) for AI Coding Agents - MCP server with SQL-backed decision repository",
-  "version": "5.3.6",
+  "version": "5.3.7",
   "main": "dist/index.js",
   "exports": {
     ".": "./dist/index.js",

--- a/src/cli/hooks/omp-plan.ts
+++ b/src/cli/hooks/omp-plan.ts
@@ -1,21 +1,27 @@
 /**
- * omp plan materialization helpers.
+ * omp plan tracking helpers.
  *
- * omp plans live as session-local `local://<slug>-plan.md` artifacts.
- * processPlanPatterns needs an absolute plan_path, so we mirror content under
- * `<project>/.sqlew/plans/<slug>-plan.md` (same idea as Grok/Codex materialize).
+ * omp plans live as session-local `local://<slug>-plan.md` artifacts on disk
+ * under the session artifacts dir (`<sessionFile-without-.jsonl>/local/`).
+ * processPlanPatterns needs an absolute plan_path, so we resolve local:// to
+ * that real path and store it on CurrentPlanInfo — no project .sqlew/plans copy.
+ *
+ * Fallback: if resolve fails, legacy-write under `.sqlew/plans/` (rare).
  *
  * @since v5.4.0
+ * @modified v5.4.2 — session-local plan_path; drop default project mirror
  */
 
 import { createHash, randomUUID } from 'crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { basename, isAbsolute, join, resolve as pathResolve, sep } from 'path';
+import { tmpdir } from 'os';
 import {
   loadCurrentPlan,
   saveCurrentPlan,
   type CurrentPlanInfo,
 } from '../../config/global-config.js';
+import { debugLog } from '../../utils/debug-logger.js';
 import { hasPatterns } from './plan-pattern-extractor.js';
 import { PLAN_TEMPLATE_MARKER } from './grok-plan-template.js';
 import { isOmpPlanPath } from './stdin-parser.js';
@@ -38,12 +44,100 @@ const OMP_PLAN_TEMPLATE = `
 ---
 `.trim();
 
+/** Match pi-coding-agent local-protocol WINDOWS_LOCAL_ROOT_MAX_CHARS */
+const WINDOWS_LOCAL_ROOT_MAX_CHARS = 180;
+
+export type OmpLocalResolveOpts = {
+  /** Absolute path to session transcript (…/<ts>_<id>.jsonl) */
+  sessionFile?: string | null;
+  /** Fallback session id for Win short root / missing sessionFile */
+  sessionId?: string | null;
+  /** Override platform (tests); default process.platform */
+  platform?: NodeJS.Platform;
+};
+
+/** Legacy project mirror dir (fallback only). */
 export function ompPlansDir(projectPath: string): string {
   return join(projectPath, '.sqlew', 'plans');
 }
 
 function contentHash(content: string): string {
   return createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+function normalizeFsPath(p: string): string {
+  return p.replace(/\\/g, '/');
+}
+
+function safeSessionId(sessionId?: string | null): string {
+  const raw = sessionId && sessionId.length > 0 ? sessionId : 'session';
+  const safe = raw.replace(/[^a-zA-Z0-9_.-]/g, '_');
+  return safe.length > 0 ? safe : 'session';
+}
+
+/**
+ * Resolve session-scoped local:// root (mirrors pi-coding-agent resolveLocalRoot).
+ */
+export function resolveOmpLocalRoot(
+  opts: OmpLocalResolveOpts,
+  platform: NodeJS.Platform = opts.platform ?? process.platform,
+): string {
+  const sessionFile = opts.sessionFile;
+  if (sessionFile) {
+    const artifactsDir = sessionFile.replace(/\.jsonl$/i, '');
+    const candidate = pathResolve(artifactsDir, 'local');
+    if (platform === 'win32' && candidate.length >= WINDOWS_LOCAL_ROOT_MAX_CHARS) {
+      return join(tmpdir(), 'omp-local', safeSessionId(opts.sessionId));
+    }
+    return candidate;
+  }
+  return join(tmpdir(), 'omp-local', safeSessionId(opts.sessionId));
+}
+
+function isPathInsideRoot(targetPath: string, rootPath: string): boolean {
+  const root = pathResolve(rootPath);
+  const target = pathResolve(targetPath);
+  if (target === root) return true;
+  const prefix = root.endsWith(sep) ? root : root + sep;
+  // Windows: compare case-insensitively
+  if (process.platform === 'win32') {
+    return target.toLowerCase().startsWith(prefix.toLowerCase());
+  }
+  return target.startsWith(prefix);
+}
+
+/**
+ * Resolve local://rel or absolute path to a normalized absolute FS path.
+ * Returns null if unresolvable or path escapes the local root.
+ */
+export function resolveOmpPlanFsPath(
+  filePath: string,
+  opts: OmpLocalResolveOpts = {},
+): string | null {
+  if (!filePath) return null;
+  const p = filePath.replace(/\\/g, '/').trim();
+  if (!p) return null;
+
+  const localMatch = /^local:\/\/(.+)$/i.exec(p);
+  if (!localMatch) {
+    if (isAbsolute(filePath) || /^[A-Za-z]:[\\/]/.test(filePath)) {
+      return normalizeFsPath(pathResolve(filePath));
+    }
+    return null;
+  }
+
+  let rel = localMatch[1] ?? '';
+  rel = rel.split('?')[0].split('#')[0];
+  rel = rel.replace(/^\/+/, '');
+  if (!rel || rel.includes('\0')) return null;
+
+  const platform = opts.platform ?? process.platform;
+  const localRoot = pathResolve(resolveOmpLocalRoot(opts, platform));
+  const resolved = pathResolve(localRoot, rel);
+  if (!isPathInsideRoot(resolved, localRoot)) {
+    return null;
+  }
+  return normalizeFsPath(resolved);
 }
 
 /**
@@ -57,7 +151,6 @@ export function extractSlugFromOmpPlanPath(filePath: string): string | null {
   if (!filePath) return null;
   const p = filePath.replace(/\\/g, '/').trim();
 
-  // propose devices are not plan slugs
   if (
     p === 'xd://propose' ||
     p === '/xdev/propose' ||
@@ -75,18 +168,16 @@ export function extractSlugFromOmpPlanPath(filePath: string): string | null {
     if (slash >= 0) name = p.slice(slash + 1);
   }
 
-  // strip query/hash if any
   name = name.split('?')[0].split('#')[0];
 
   if (!name.toLowerCase().endsWith('.md')) {
-    // bare slug without -plan.md
     if (name.length > 0 && !name.includes('/')) {
       return name.replace(/-plan$/i, '') || null;
     }
     return null;
   }
 
-  const base = name.slice(0, -3); // drop .md
+  const base = name.slice(0, -3);
   const withoutPlan = base.replace(/-plan$/i, '');
   return withoutPlan.length > 0 ? withoutPlan : null;
 }
@@ -109,37 +200,57 @@ export function ensureOmpPlanTemplate(content: string): {
 }
 
 /**
- * Write plan content under .sqlew/plans and update CurrentPlanInfo.
+ * Track an omp plan at an absolute FS path (session local). Does NOT write the
+ * plan body — harness owns local:// content. Updates CurrentPlanInfo only.
+ *
+ * Name kept for API compatibility with older callers that expected a project mirror.
  */
 export function materializeOmpPlan(opts: {
   projectPath: string;
   slug: string;
-  content: string;
+  content?: string;
+  /** Absolute FS path of the plan body (session local or legacy). Required. */
+  planPath: string;
   sessionId?: string;
 }): { planPath: string; planInfo: CurrentPlanInfo } {
-  const { projectPath, slug, content } = opts;
-  const safeSlug = slug.replace(/[^a-zA-Z0-9._-]/g, '-').replace(/^-+|-+$/g, '') || 'plan';
-  const planFile = `${safeSlug}-plan.md`;
-  const dir = ompPlansDir(projectPath);
-  mkdirSync(dir, { recursive: true });
-  const planPath = join(dir, planFile).replace(/\\/g, '/');
+  const { projectPath, planPath, content } = opts;
+  if (!planPath) {
+    throw new Error('materializeOmpPlan: planPath is required');
+  }
+
+  const normalizedPath = normalizeFsPath(planPath);
+  const planFile = basename(normalizedPath);
+
+  let newHash: string | undefined;
+  if (content !== undefined) {
+    newHash = contentHash(content);
+  } else if (existsSync(planPath)) {
+    try {
+      newHash = contentHash(readFileSync(planPath, 'utf-8'));
+    } catch {
+      newHash = undefined;
+    }
+  }
 
   const existing = loadCurrentPlan(projectPath);
   const samePath =
-    existing?.plan_path?.replace(/\\/g, '/') === planPath ||
+    existing?.plan_path?.replace(/\\/g, '/') === normalizedPath ||
     existing?.plan_file === planFile;
 
   let previousHash: string | undefined;
-  if (samePath && existsSync(planPath)) {
+  if (samePath && existing?.plan_path && existsSync(existing.plan_path)) {
+    try {
+      previousHash = contentHash(readFileSync(existing.plan_path, 'utf-8'));
+    } catch {
+      previousHash = undefined;
+    }
+  } else if (samePath && existsSync(planPath)) {
     try {
       previousHash = contentHash(readFileSync(planPath, 'utf-8'));
     } catch {
       previousHash = undefined;
     }
   }
-
-  writeFileSync(planPath, content, 'utf-8');
-  const newHash = contentHash(content);
 
   let recorded = false;
   let planId: string = randomUUID();
@@ -149,11 +260,18 @@ export function materializeOmpPlan(opts: {
   if (samePath && existing) {
     planId = existing.plan_id;
     enforcementShownAt = existing.enforcement_shown_at;
-    if (existing.recorded && previousHash === newHash) {
-      recorded = true;
-      decisionPending = existing.decision_pending ?? false;
-    } else if (existing.recorded && previousHash !== newHash) {
-      // content changed after recorded → allow re-extract
+
+    if (existing.recorded && newHash !== undefined && previousHash !== undefined) {
+      if (previousHash === newHash) {
+        recorded = true;
+        decisionPending = existing.decision_pending ?? false;
+      } else {
+        // content changed after recorded → allow re-extract
+        recorded = false;
+        decisionPending = true;
+      }
+    } else if (existing.recorded && newHash !== undefined && previousHash === undefined) {
+      // No prior disk bytes to compare — treat as pending re-extract
       recorded = false;
       decisionPending = true;
     } else {
@@ -165,67 +283,73 @@ export function materializeOmpPlan(opts: {
   const planInfo: CurrentPlanInfo = {
     plan_id: planId,
     plan_file: planFile,
-    plan_path: planPath,
+    plan_path: normalizedPath,
     plan_updated_at: new Date().toISOString(),
     recorded,
     decision_pending: decisionPending,
     enforcement_shown_at: enforcementShownAt,
   };
   saveCurrentPlan(projectPath, planInfo);
-  return { planPath, planInfo };
+  return { planPath: normalizedPath, planInfo };
 }
 
 /**
- * Track omp plan from a path (local:// or absolute materialized).
- * When content is provided, materializes/updates the file.
+ * Legacy fallback: write content under .sqlew/plans and track.
+ * Only used when local:// cannot be resolved.
+ */
+function legacyMaterializeToProject(opts: {
+  projectPath: string;
+  slug: string;
+  content: string;
+}): CurrentPlanInfo {
+  const { projectPath, slug, content } = opts;
+  const safeSlug =
+    slug.replace(/[^a-zA-Z0-9._-]/g, '-').replace(/^-+|-+$/g, '') || 'plan';
+  const planFile = `${safeSlug}-plan.md`;
+  const dir = ompPlansDir(projectPath);
+  mkdirSync(dir, { recursive: true });
+  const planPath = normalizeFsPath(join(dir, planFile));
+  writeFileSync(planPath, content, 'utf-8');
+  debugLog('DEBUG', '[omp-plan] local resolve failed; fallback materialize to .sqlew/plans', {
+    planPath,
+  });
+  return materializeOmpPlan({
+    projectPath,
+    slug: safeSlug,
+    content,
+    planPath,
+  }).planInfo;
+}
+
+/**
+ * Track omp plan from a path (local:// or absolute).
+ * Prefer resolving local:// to the session file; no project copy on success.
  */
 export function trackOmpPlanFromPath(opts: {
   projectPath: string;
   filePath: string;
   content?: string;
   sessionId?: string;
+  sessionFile?: string | null;
 }): CurrentPlanInfo {
-  const { projectPath, filePath, content, sessionId } = opts;
+  const { projectPath, filePath, content, sessionId, sessionFile } = opts;
   const slug = extractSlugFromOmpPlanPath(filePath) ?? 'plan';
+  const abs = resolveOmpPlanFsPath(filePath, { sessionFile, sessionId });
 
-  if (content !== undefined) {
-    return materializeOmpPlan({ projectPath, slug, content, sessionId }).planInfo;
-  }
-
-  // No content: if already materialized, just refresh tracking metadata
-  const planFile = `${slug}-plan.md`;
-  const planPath = join(ompPlansDir(projectPath), planFile).replace(/\\/g, '/');
-
-  if (existsSync(planPath)) {
-    const existingContent = readFileSync(planPath, 'utf-8');
+  if (abs) {
     return materializeOmpPlan({
       projectPath,
       slug,
-      content: existingContent,
+      content,
+      planPath: abs,
       sessionId,
     }).planInfo;
   }
 
-  // Absolute path that is already a real file
-  const normalized = filePath.replace(/\\/g, '/');
-  if (!normalized.startsWith('local://') && existsSync(filePath)) {
-    const fileContent = readFileSync(filePath, 'utf-8');
-    return materializeOmpPlan({
-      projectPath,
-      slug,
-      content: fileContent,
-      sessionId,
-    }).planInfo;
-  }
-
-  // Create empty tracked plan with template
-  const { content: templated } = ensureOmpPlanTemplate('');
-  return materializeOmpPlan({
-    projectPath,
-    slug,
-    content: templated,
-    sessionId,
-  }).planInfo;
+  // Resolve failed — legacy project mirror
+  const body =
+    content !== undefined ? content : ensureOmpPlanTemplate('').content;
+  return legacyMaterializeToProject({ projectPath, slug, content: body });
 }
 
 export { isOmpPlanPath, OMP_PLAN_TEMPLATE, PLAN_TEMPLATE_MARKER };

--- a/src/hooks-api.ts
+++ b/src/hooks-api.ts
@@ -57,6 +57,9 @@ export {
   trackOmpPlanFromPath,
   extractSlugFromOmpPlanPath,
   ensureOmpPlanTemplate,
+  resolveOmpPlanFsPath,
+  resolveOmpLocalRoot,
+  type OmpLocalResolveOpts,
 } from './cli/hooks/omp-plan.js';
 
 export {

--- a/src/tests/integration/omp-plan-to-adr.test.ts
+++ b/src/tests/integration/omp-plan-to-adr.test.ts
@@ -2,6 +2,7 @@
  * omp Plan-to-ADR integration tests (no omp binary required)
  *
  * @since v5.4.0
+ * @modified v5.4.2 — session-local plan_path (no project mirror)
  */
 
 import { describe, it, beforeEach, afterEach } from 'node:test';
@@ -9,7 +10,11 @@ import assert from 'node:assert/strict';
 import { existsSync, mkdirSync, rmSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { materializeOmpPlan, ensureOmpPlanTemplate } from '../../cli/hooks/omp-plan.js';
+import {
+  materializeOmpPlan,
+  ensureOmpPlanTemplate,
+  ompPlansDir,
+} from '../../cli/hooks/omp-plan.js';
 import { processPlanPatterns } from '../../cli/hooks/plan-processor.js';
 import { hasFilledPatterns } from '../../cli/hooks/plan-pattern-extractor.js';
 import { saveCurrentPlan, loadCurrentPlan } from '../../config/global-config.js';
@@ -23,6 +28,7 @@ const FILLED_PLAN = `# Demo plan
 `;
 
 let testProjectPath: string;
+let sessionPlanPath: string;
 
 describe('omp plan-to-adr', () => {
   beforeEach(() => {
@@ -30,7 +36,10 @@ describe('omp plan-to-adr', () => {
       tmpdir(),
       `sqlew-omp-adr-${Date.now()}-${Math.random().toString(36).slice(2)}`,
     );
-    mkdirSync(join(testProjectPath, '.sqlew', 'plans'), { recursive: true });
+    mkdirSync(testProjectPath, { recursive: true });
+    const localDir = join(testProjectPath, 'session-local');
+    mkdirSync(localDir, { recursive: true });
+    sessionPlanPath = join(localDir, 'demo-plan.md');
   });
 
   afterEach(() => {
@@ -39,13 +48,17 @@ describe('omp plan-to-adr', () => {
     }
   });
 
-  it('processPlanPatterns enqueues decision from materialized plan', () => {
+  it('processPlanPatterns enqueues decision from session-local plan', () => {
+    writeFileSync(sessionPlanPath, FILLED_PLAN, 'utf-8');
     const { planPath } = materializeOmpPlan({
       projectPath: testProjectPath,
       slug: 'demo',
       content: FILLED_PLAN,
+      planPath: sessionPlanPath,
     });
     assert.ok(existsSync(planPath));
+    assert.equal(planPath.replace(/\\/g, '/'), sessionPlanPath.replace(/\\/g, '/'));
+    assert.equal(existsSync(ompPlansDir(testProjectPath)), false);
     assert.equal(hasFilledPatterns(FILLED_PLAN), true);
 
     const result = processPlanPatterns(testProjectPath);
@@ -66,10 +79,12 @@ describe('omp plan-to-adr', () => {
   });
 
   it('second processPlanPatterns returns already_recorded', () => {
+    writeFileSync(sessionPlanPath, FILLED_PLAN, 'utf-8');
     materializeOmpPlan({
       projectPath: testProjectPath,
       slug: 'demo',
       content: FILLED_PLAN,
+      planPath: sessionPlanPath,
     });
     const first = processPlanPatterns(testProjectPath);
     assert.equal(first.processed, true);
@@ -89,17 +104,16 @@ describe('omp plan-to-adr', () => {
 
     // Propose gate uses hasFilledPatterns; processPlanPatterns still sees
     // raw 📌/🚫 headings via hasPatterns — gate is what blocks empty proposes.
-    writeFileSync(join(testProjectPath, '.sqlew', 'plans', 'empty-plan.md'), content, 'utf-8');
+    writeFileSync(sessionPlanPath, content, 'utf-8');
     saveCurrentPlan(testProjectPath, {
       plan_id: 'empty-1',
-      plan_file: 'empty-plan.md',
-      plan_path: join(testProjectPath, '.sqlew', 'plans', 'empty-plan.md').replace(/\\/g, '/'),
+      plan_file: 'demo-plan.md',
+      plan_path: sessionPlanPath.replace(/\\/g, '/'),
       plan_updated_at: new Date().toISOString(),
       recorded: false,
       decision_pending: true,
     });
 
-    // If extraction yields only placeholders, hasFilledPatterns remains the gate.
-    assert.equal(hasFilledPatterns(readFileSync(join(testProjectPath, '.sqlew', 'plans', 'empty-plan.md'), 'utf-8')), false);
+    assert.equal(hasFilledPatterns(readFileSync(sessionPlanPath, 'utf-8')), false);
   });
 });

--- a/src/tests/unit/hooks/omp-plan.test.ts
+++ b/src/tests/unit/hooks/omp-plan.test.ts
@@ -1,12 +1,13 @@
 /**
- * omp plan materialize helpers unit tests
+ * omp plan tracking helpers unit tests
  *
  * @since v5.4.0
+ * @modified v5.4.2 — session-local plan_path (no project mirror)
  */
 
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { existsSync, mkdirSync, rmSync, readFileSync } from 'fs';
+import { existsSync, mkdirSync, rmSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
@@ -14,12 +15,17 @@ import {
   materializeOmpPlan,
   ensureOmpPlanTemplate,
   ompPlansDir,
+  resolveOmpPlanFsPath,
+  resolveOmpLocalRoot,
+  trackOmpPlanFromPath,
 } from '../../../cli/hooks/omp-plan.js';
 import { isOmpPlanPath } from '../../../cli/hooks/stdin-parser.js';
 import { loadCurrentPlan, saveCurrentPlan } from '../../../config/global-config.js';
 import { PLAN_TEMPLATE_MARKER } from '../../../cli/hooks/grok-plan-template.js';
 
 let testProjectPath: string;
+let sessionLocalDir: string;
+let sessionFile: string;
 
 describe('omp-plan helpers', () => {
   beforeEach(() => {
@@ -28,6 +34,15 @@ describe('omp-plan helpers', () => {
       `sqlew-omp-plan-${Date.now()}-${Math.random().toString(36).slice(2)}`,
     );
     mkdirSync(testProjectPath, { recursive: true });
+    // Fake omp session layout: <artifactsDir>.jsonl + <artifactsDir>/local/
+    const artifactsDir = join(
+      testProjectPath,
+      'sess-2026-01-01T00-00-00Z_abc123',
+    );
+    sessionFile = `${artifactsDir}.jsonl`;
+    sessionLocalDir = join(artifactsDir, 'local');
+    mkdirSync(sessionLocalDir, { recursive: true });
+    writeFileSync(sessionFile, '', 'utf-8');
   });
 
   afterEach(() => {
@@ -91,35 +106,93 @@ describe('omp-plan helpers', () => {
     });
   });
 
+  describe('resolveOmpPlanFsPath', () => {
+    it('resolves local:// under session artifacts local/', () => {
+      const abs = resolveOmpPlanFsPath('local://demo-plan.md', {
+        sessionFile,
+        sessionId: 'abc123',
+        platform: 'linux',
+      });
+      assert.ok(abs);
+      assert.equal(
+        abs!.replace(/\\/g, '/'),
+        join(sessionLocalDir, 'demo-plan.md').replace(/\\/g, '/'),
+      );
+    });
+
+    it('rejects path traversal outside local root', () => {
+      const abs = resolveOmpPlanFsPath('local://../secret.md', {
+        sessionFile,
+        sessionId: 'abc123',
+        platform: 'linux',
+      });
+      assert.equal(abs, null);
+    });
+
+    it('returns absolute paths normalized', () => {
+      const target = join(sessionLocalDir, 'x-plan.md');
+      const abs = resolveOmpPlanFsPath(target, { sessionFile });
+      assert.ok(abs);
+      assert.equal(abs!.replace(/\\/g, '/'), target.replace(/\\/g, '/'));
+    });
+
+    it('falls back to tmpdir short root without sessionFile', () => {
+      const root = resolveOmpLocalRoot(
+        { sessionId: 'sid1', platform: 'linux' },
+        'linux',
+      );
+      assert.ok(root.replace(/\\/g, '/').includes('omp-local'));
+      assert.ok(root.replace(/\\/g, '/').endsWith('sid1') || root.includes('sid1'));
+
+      const abs = resolveOmpPlanFsPath('local://p-plan.md', {
+        sessionId: 'sid1',
+        platform: 'linux',
+      });
+      assert.ok(abs);
+      assert.ok(abs!.replace(/\\/g, '/').endsWith('/p-plan.md'));
+      assert.ok(abs!.includes('omp-local'));
+    });
+  });
+
   describe('materializeOmpPlan', () => {
-    it('writes file and CurrentPlanInfo with absolute plan_path', () => {
+    it('tracks CurrentPlanInfo without writing .sqlew/plans', () => {
       const content = '# demo\n';
-      const { planPath, planInfo } = materializeOmpPlan({
+      const planPath = join(sessionLocalDir, 'demo-plan.md');
+      writeFileSync(planPath, content, 'utf-8');
+
+      const { planPath: tracked, planInfo } = materializeOmpPlan({
         projectPath: testProjectPath,
         slug: 'demo',
         content,
+        planPath,
       });
 
-      assert.ok(existsSync(planPath));
+      assert.equal(tracked.replace(/\\/g, '/'), planPath.replace(/\\/g, '/'));
       assert.equal(readFileSync(planPath, 'utf-8'), content);
-      assert.ok(planPath.replace(/\\/g, '/').endsWith('.sqlew/plans/demo-plan.md'));
+      assert.equal(existsSync(ompPlansDir(testProjectPath)), false);
 
       const loaded = loadCurrentPlan(testProjectPath);
       assert.ok(loaded);
       assert.equal(loaded.plan_file, 'demo-plan.md');
-      assert.equal(loaded.plan_path?.replace(/\\/g, '/'), planPath.replace(/\\/g, '/'));
+      assert.equal(
+        loaded.plan_path?.replace(/\\/g, '/'),
+        planPath.replace(/\\/g, '/'),
+      );
       assert.equal(loaded.recorded, false);
       assert.equal(loaded.decision_pending, true);
       assert.equal(planInfo.plan_id, loaded.plan_id);
-      assert.ok(existsSync(ompPlansDir(testProjectPath)));
     });
 
     it('keeps recorded when content hash unchanged', () => {
       const content = '# same\n';
+      const planPath = join(sessionLocalDir, 'same-plan.md');
+      writeFileSync(planPath, content, 'utf-8');
+
       const first = materializeOmpPlan({
         projectPath: testProjectPath,
         slug: 'same',
         content,
+        planPath,
       });
       saveCurrentPlan(testProjectPath, {
         ...first.planInfo,
@@ -131,16 +204,22 @@ describe('omp-plan helpers', () => {
         projectPath: testProjectPath,
         slug: 'same',
         content,
+        planPath,
       });
       assert.equal(second.planInfo.recorded, true);
       assert.equal(second.planInfo.plan_id, first.planInfo.plan_id);
+      assert.equal(existsSync(ompPlansDir(testProjectPath)), false);
     });
 
     it('resets recorded when content changes', () => {
+      const planPath = join(sessionLocalDir, 'rev-plan.md');
+      writeFileSync(planPath, '# v1\n', 'utf-8');
+
       const first = materializeOmpPlan({
         projectPath: testProjectPath,
         slug: 'rev',
         content: '# v1\n',
+        planPath,
       });
       saveCurrentPlan(testProjectPath, {
         ...first.planInfo,
@@ -152,9 +231,59 @@ describe('omp-plan helpers', () => {
         projectPath: testProjectPath,
         slug: 'rev',
         content: '# v2 changed\n',
+        planPath,
       });
       assert.equal(second.planInfo.recorded, false);
       assert.equal(second.planInfo.decision_pending, true);
+    });
+  });
+
+  describe('trackOmpPlanFromPath', () => {
+    it('resolves local:// via sessionFile without project mirror', () => {
+      const content = '# tracked\n';
+      const diskPath = join(sessionLocalDir, 'tracked-plan.md');
+      writeFileSync(diskPath, content, 'utf-8');
+
+      const info = trackOmpPlanFromPath({
+        projectPath: testProjectPath,
+        filePath: 'local://tracked-plan.md',
+        content,
+        sessionFile,
+        sessionId: 'abc123',
+      });
+
+      assert.equal(
+        info.plan_path?.replace(/\\/g, '/'),
+        diskPath.replace(/\\/g, '/'),
+      );
+      assert.equal(existsSync(ompPlansDir(testProjectPath)), false);
+    });
+
+    it('legacy-mirrors when local:// cannot be resolved', () => {
+      const content = '# fallback\n';
+      const info = trackOmpPlanFromPath({
+        projectPath: testProjectPath,
+        filePath: 'local://fallback-plan.md',
+        content,
+        // no sessionFile / sessionId → still resolves via tmp short root
+        // force failure with empty path-like that is not local and not absolute:
+      });
+      // With sessionId default short root, resolve succeeds. Use non-local relative:
+      const info2 = trackOmpPlanFromPath({
+        projectPath: testProjectPath,
+        filePath: 'not-a-local-plan.md',
+        content,
+      });
+      // extractSlug works on bare name; resolve returns null for relative non-local
+      // → legacy mirror
+      assert.ok(info2.plan_path);
+      assert.ok(
+        info2.plan_path!.replace(/\\/g, '/').includes('.sqlew/plans/'),
+        info2.plan_path,
+      );
+      assert.ok(existsSync(info2.plan_path!));
+      // silence unused
+      void info;
     });
   });
 });


### PR DESCRIPTION
## Summary

- Resolve omp `'C:\Users\kitayama\.omp\agent\sessions\-RustroverProjects-mcp-sqlew\2026-07-31T01-43-12-530Z_019fb5d6-f993-7000-82d4-e74106814be8\local\*-plan.md'` to the session artifacts file and store that absolute path as `CurrentPlanInfo.plan_path`
- Stop default-mirroring plans into project `.sqlew/plans/` (legacy fallback only when resolve fails)
- Export `resolveOmpPlanFsPath` / `resolveOmpLocalRoot` from `sqlew/hooks`; bump to **5.3.7**

## Architecture Decisions

### Decision: harness/omp/plan-path-session-local (session local file is enough for processPlanPatterns)

omp plans already exist on disk under the session `local/` tree. Copying into `<project>/.sqlew/plans/` was only to give `processPlanPatterns` an absolute `plan_path`, and it left gitignored junk in the project.

- `src/cli/hooks/omp-plan.ts`: add resolve helpers (same formula as pi-coding-agent, no runtime dep); `materializeOmpPlan` tracks metadata only; legacy project mirror on resolve failure
- `src/hooks-api.ts`: export resolve helpers for the omp Extension
- `src/tests/unit/hooks/omp-plan.test.ts` / `src/tests/integration/omp-plan-to-adr.test.ts`: session-local contract, no default mirror
- `docs/HOOKS_GUIDE.md` / `docs/HARNESS_COMPATIBILITY.md` / `docs/CONFIGURATION.md`: document session-local track

### Constraint: no `@oh-my-pi/pi-coding-agent` runtime dependency on sqlew

hooks-api is shared across harnesses; only the resolve formula is duplicated in `omp-plan.ts`.

### Constraint: keep `processPlanPatterns(projectPath)` signature

Shared entry point unchanged; omp difference is which absolute path is stored before extract.

## Other Changes

- `package.json` / `CHANGELOG.md`: **5.3.7**

## Test Plan

- [x] `node --import tsx --test src/tests/unit/hooks/omp-plan.test.ts src/tests/integration/omp-plan-to-adr.test.ts` (20/20)
- [x] pre-commit full suite
- [x] manual omp E2E after `npm link`: `plan_path` under `.../sessions/.../local/`, no new `.sqlew/plans` file, extract via HIGH-SIMILARITY auto-update

Pairs with sqlew-plugin PR (Extension `sessionFile` + `planPath`, v5.4.1).